### PR TITLE
WEBDEV-8131 Encapsulate property settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,54 +148,61 @@ Import your story in `/demo/app-root.ts` and add it to the page.
 
 The story template is a component you can use in your story to demo your component. This lets us present them in a consistent way.
 
-It has 5 main configurations:
+It has a few main configurations:
 
 *Properties*
 - `elementTag` (_string_) your component's name, ie `ia-button`
-- `exampleUsage` (_string_) your element's example usage, displays it with syntax highlighting
 - `labs` (_boolean_) if your component is in `labs` to update links
+- `styleInputSettings` (_StyleInputSettings array_) the style options to display, in the appropriate format
+- `propInputSettings` (_PropInputSettings array_) the prop options to display, in the appropriate format
+
+**Note:** If the type of prop input you want to use isn't yet available in the `propInputSettings` options,
+you can instead slot in custom property settings by using `slot="settings"`, adding a button to apply the
+properties, and passing in a `customExampleUsage` (see `ia-snow-story.ts` for a sample implementation).
 
 *Slots*
 - `demo` put your component demo in here
-- `settings` put your component settings in here
 
 Here's an example:
 ```typescript
 import '@demo/story-template';
+
+// Style options to display
+const styleInputSettings: StyleInputSettings[] = [
+  {
+    label: 'Button BG color',
+    cssVariable: '--button-background-color',
+    defaultValue: 'blue',  // Should match the actual fallback value for the variable
+    inputType: 'color',
+  },
+];
+
+// Prop options to display
+const propInputSettings: PropInputSettings[] = [
+  {
+    label: 'Mode',
+    inputType: 'radio',
+    propertyName: 'mode', // Should match the name of the property from its @property() declaration
+    radioOptions: ['primary', 'secondary', 'danger'],
+    defaultValue: 'primary', // Should match the actual default value from the @property() declaration, if any
+  },
+]
 ...
 render() {
   return html`
-    <story-template elementTag="ia-button" elementClassName="IAButton" .exampleUsage=${this.exampleUsage}>
+    <story-template 
+      elementTag="ia-button" 
+      elementClassName="IAButton" 
+      .styleInputSettings=${this.styleInputSettings} 
+      .propInputSettings=${this.propInputSettings}
+    >
       <div slot="demo">
-        <ia-button @click=${() => alert('Button clicked!')}
-          >Click Me</ia-button
-        >
-      </div>
-
-      <div slot="settings">
-        <table>
-          <tr>
-            <td>Color</td>
-            <td><input type="color" value="#007bff" id="color" /></td>
-          </tr>
-        </table>
-        <button @click=${this.apply}>Apply</button>
+        <ia-button @click=${() => alert('Button clicked!')}>
+          Click Me
+        </ia-button>
       </div>
     </story-template>
   `;
-}
-
-// return a string of your element's usage and it will
-// be displayed with syntax highlighting
-// can be dynamic
-private get exampleUsage(): string {
-  return `<ia-button @click=\${() => alert('Button clicked!')}>
-    Click Me
-  </ia-button>`;
-}
-
-private apply(): void {
-  // update component settings based on settings change
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ render() {
     <story-template 
       elementTag="ia-button" 
       elementClassName="IAButton" 
-      .styleInputSettings=${this.styleInputSettings} 
-      .propInputSettings=${this.propInputSettings}
+      .styleInputData=${{settings: this.styleInputSettings}} 
+      .propInputData=${{settings: this.propInputSettings}}
     >
       <div slot="demo">
         <ia-button @click=${() => alert('Button clicked!')}>

--- a/demo/story-components/story-prop-settings.ts
+++ b/demo/story-components/story-prop-settings.ts
@@ -1,0 +1,153 @@
+import {
+  css,
+  html,
+  LitElement,
+  nothing,
+  TemplateResult,
+  type CSSResultGroup,
+} from 'lit';
+import { property, queryAll } from 'lit/decorators.js';
+import { customElement } from 'lit/decorators/custom-element.js';
+import { choose } from 'lit/directives/choose.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+import themeStyles from '@src/themes/theme-styles';
+import { labelToId } from '../story-utils';
+
+export type PropInputSettings<T> = {
+  label: string;
+  propertyName: keyof T;
+  defaultValue?: string;
+  inputType?: 'text' | 'radio';
+  radioOptions?: string[];
+};
+
+export type PropInputData = {
+  settings: PropInputSettings<any>[];
+};
+
+export type AppliedProps = {
+  propName: string;
+  value: string | boolean | number;
+}[];
+
+/**
+ * A template for displaying the prop options.
+ */
+@customElement('story-props-settings')
+export class StoryTemplate extends LitElement {
+  @property({ type: Object }) propInputData?: PropInputData;
+
+  @queryAll('.prop-input')
+  private propInputs?: NodeListOf<HTMLInputElement>;
+
+  render() {
+    if (!this.propInputData) return nothing;
+
+    return html`
+      <h3>Properties</h3>
+      <div class="settings-options">
+        <table>
+          ${this.propInputData.settings.map(
+            (input) =>
+              choose(
+                input.inputType,
+                [['radio', () => this.createRadioPropInput(input)]],
+                () => this.createDefaultPropInput(input),
+              ) ?? nothing,
+          )}
+        </table>
+        <button @click=${this.applyProps}>Apply</button>
+      </div>
+    `;
+  }
+
+  private createDefaultPropInput(
+    settings: PropInputSettings<any>,
+  ): TemplateResult | typeof nothing {
+    const inputId = labelToId(settings.label);
+
+    return html`
+      <tr>
+        <td><label for=${inputId}>${settings.label}</label></td>
+        <td>
+          <input
+            class="prop-input"
+            type=${settings.inputType ?? 'text'}
+            id=${inputId}
+            data-prop=${settings.propertyName}
+            placeholder=${ifDefined(settings?.defaultValue)}
+          />
+        </td>
+      </tr>
+    `;
+  }
+
+  private createRadioPropInput(
+    settings: PropInputSettings<any>,
+  ): TemplateResult | typeof nothing {
+    if (settings.inputType !== 'radio' || !settings.radioOptions)
+      return nothing;
+
+    const inputId = labelToId(settings.label);
+
+    return html`
+      <tr>
+        <td><legend>${settings.label}</legend></td>
+        <td>
+          ${settings.radioOptions.map(
+            (option) =>
+              html`<input
+                  type="radio"
+                  class="prop-input"
+                  name=${inputId}
+                  id=${option}
+                  value=${option}
+                  data-prop=${settings.propertyName}
+                  ?checked=${settings.defaultValue === option}
+                /><label for=${option}> ${option} </label>`,
+          )}
+        </td>
+      </tr>
+    `;
+  }
+
+  /* Applies properties to demo component */
+  private applyProps() {
+    const stringifiedProps: string[] = [];
+    const appliedProps: AppliedProps = [];
+    this.propInputs?.forEach((input) => {
+      if (
+        !input.dataset.prop ||
+        !input.value ||
+        (input.type === 'radio' && !input.checked)
+      )
+        return;
+
+      const propName = input.dataset.prop;
+      stringifiedProps.push(`.${propName}=\${'${input.value}'}`);
+      appliedProps.push({ propName, value: input.value });
+    });
+
+    this.dispatchEvent(
+      new CustomEvent('propsApplied', {
+        detail: {
+          stringifiedProps: '\n  ' + stringifiedProps.join('\n  ') + '\n',
+          appliedProps,
+        },
+      }),
+    );
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      themeStyles,
+      css`
+        .settings-options {
+          background-color: var(--primary-background-color);
+          padding: 1em;
+        }
+      `,
+    ];
+  }
+}

--- a/demo/story-components/story-prop-settings.ts
+++ b/demo/story-components/story-prop-settings.ts
@@ -101,11 +101,11 @@ export class StoryPropsSettings extends LitElement {
                   type="radio"
                   class="prop-input"
                   name=${inputId}
-                  id=${'${inputId}-${option}'}
+                  id="${inputId}-${option}"
                   value=${option}
                   data-prop=${settings.propertyName}
                   ?checked=${settings.defaultValue === option}
-                /><label for=${'${inputId}-${option}'}> ${option} </label>`,
+                /><label for="${inputId}-${option}"> ${option} </label>`,
           )}
         </td>
       </tr>

--- a/demo/story-components/story-prop-settings.ts
+++ b/demo/story-components/story-prop-settings.ts
@@ -101,11 +101,11 @@ export class StoryPropsSettings extends LitElement {
                   type="radio"
                   class="prop-input"
                   name=${inputId}
-                  id=${option}
+                  id=${'${inputId}-${option}'}
                   value=${option}
                   data-prop=${settings.propertyName}
                   ?checked=${settings.defaultValue === option}
-                /><label for=${option}> ${option} </label>`,
+                /><label for=${'${inputId}-${option}'}> ${option} </label>`,
           )}
         </td>
       </tr>

--- a/demo/story-components/story-prop-settings.ts
+++ b/demo/story-components/story-prop-settings.ts
@@ -35,7 +35,7 @@ export type AppliedProps = {
  * A template for displaying the prop options.
  */
 @customElement('story-props-settings')
-export class StoryTemplate extends LitElement {
+export class StoryPropsSettings extends LitElement {
   @property({ type: Object }) propInputData?: PropInputData;
 
   @queryAll('.prop-input')

--- a/demo/story-components/story-styles-settings.ts
+++ b/demo/story-components/story-styles-settings.ts
@@ -1,0 +1,87 @@
+import { css, html, LitElement, nothing, type CSSResultGroup } from 'lit';
+import { property, queryAll } from 'lit/decorators.js';
+import { customElement } from 'lit/decorators/custom-element.js';
+
+import themeStyles from '@src/themes/theme-styles';
+import { labelToId } from '../story-utils';
+
+export type StyleInputSettings = {
+  label: string;
+  cssVariable: string;
+  defaultValue?: string;
+  inputType?: 'color' | 'text';
+};
+
+export type StyleInputData = {
+  settings: StyleInputSettings[];
+};
+
+/**
+ * A template for display the style options.
+ */
+@customElement('story-styles-settings')
+export class StoryTemplate extends LitElement {
+  @property({ type: Object }) styleInputData?: StyleInputData;
+
+  @queryAll('.style-input')
+  private styleInputs?: NodeListOf<HTMLInputElement>;
+
+  render() {
+    if (!this.styleInputData) return nothing;
+
+    return html`
+      <h3>Styles</h3>
+      <div class="settings-options">
+        <table>
+          ${this.styleInputData.settings.map(
+            (input) => html`
+              <tr>
+                <td>
+                  <label for=${labelToId(input.label)}>${input.label}</label>
+                </td>
+                <td>
+                  <input
+                    id=${labelToId(input.label)}
+                    class="style-input"
+                    type=${input.inputType ?? 'text'}
+                    value=${input.defaultValue ?? ''}
+                    data-variable=${input.cssVariable}
+                  />
+                </td>
+              </tr>
+            `,
+          )}
+        </table>
+        <button @click=${this.applyStyles}>Apply</button>
+      </div>
+    `;
+  }
+
+  /* Applies styles to demo component. */
+  private applyStyles(): void {
+    const appliedStyles: string[] = [];
+
+    this.styleInputs?.forEach((input) => {
+      if (!input.dataset.variable || !input.value) return;
+      appliedStyles.push(`${input.dataset.variable}: ${input.value};`);
+    });
+
+    this.dispatchEvent(
+      new CustomEvent('stylesApplied', {
+        detail: { styles: appliedStyles.join('\n ') },
+      }),
+    );
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      themeStyles,
+      css`
+        .settings-options {
+          background-color: var(--primary-background-color);
+          padding: 1em;
+        }
+      `,
+    ];
+  }
+}

--- a/demo/story-components/story-styles-settings.ts
+++ b/demo/story-components/story-styles-settings.ts
@@ -17,10 +17,10 @@ export type StyleInputData = {
 };
 
 /**
- * A template for display the style options.
+ * A template for displaying the style options.
  */
 @customElement('story-styles-settings')
-export class StoryTemplate extends LitElement {
+export class StoryStylesSettings extends LitElement {
   @property({ type: Object }) styleInputData?: StyleInputData;
 
   @queryAll('.style-input')

--- a/demo/story-template.ts
+++ b/demo/story-template.ts
@@ -29,6 +29,9 @@ export class StoryTemplate extends LitElement {
 
   @property({ type: String }) customExampleUsage?: string;
 
+  /* Optional stringified properties to always include in the example usage */
+  @property({ type: String }) defaultUsageProps?: string;
+
   @property({ type: Object }) styleInputData?: StyleInputData;
 
   @property({ type: Object }) propInputData?: PropInputData;
@@ -138,7 +141,7 @@ import '${this.modulePath}';
   }
 
   private get exampleUsage(): string {
-    return `<${this.elementTag}${this.stringifiedProps ?? ''}></${this.elementTag}>`;
+    return `<${this.elementTag}${when(this.defaultUsageProps, () => '\n ' + this.defaultUsageProps + '\n')}${this.stringifiedProps ?? ''}></${this.elementTag}>`;
   }
 
   private get cssCode(): string {

--- a/demo/story-template.ts
+++ b/demo/story-template.ts
@@ -141,7 +141,7 @@ import '${this.modulePath}';
   }
 
   private get exampleUsage(): string {
-    return `<${this.elementTag}${when(this.defaultUsageProps, () => '\n ' + this.defaultUsageProps + '\n')}${this.stringifiedProps ?? ''}></${this.elementTag}>`;
+    return `<${this.elementTag}${this.defaultUsageProps ? '\n ' + this.defaultUsageProps + '\n' : ''}${this.stringifiedProps ?? ''}></${this.elementTag}>`;
   }
 
   private get cssCode(): string {

--- a/demo/story-template.ts
+++ b/demo/story-template.ts
@@ -27,7 +27,7 @@ export class StoryTemplate extends LitElement {
 
   @property({ type: String }) elementClassName = '';
 
-  @property({ type: String }) exampleUsage = '';
+  @property({ type: String }) customExampleUsage?: string;
 
   @property({ type: Object }) styleInputData?: StyleInputData;
 
@@ -42,6 +42,9 @@ export class StoryTemplate extends LitElement {
 
   /* Stringified properties for the component in .myprop=${'foo'} format */
   @state() private stringifiedProps?: string;
+
+  /* Whether settings inputs have been slotted in and should be displayed */
+  @state() private shouldShowPropertySettings: boolean = false;
 
   /* Component that has been slotted into the demo, if applicable */
   @state() private slottedDemoComponent?: any;
@@ -87,7 +90,9 @@ export class StoryTemplate extends LitElement {
         <h3>Usage</h3>
         <syntax-highlighter
           language="auto"
-          .code=${this.demoUsage}
+          .code=${this.customExampleUsage
+            ? this.customExampleUsage
+            : this.exampleUsage}
         ></syntax-highlighter>
         ${when(
           this.cssCode,
@@ -107,6 +112,14 @@ export class StoryTemplate extends LitElement {
           .propInputData=${this.propInputData}
           @propsApplied=${this.handlePropsApplied}
         ></story-props-settings>
+        ${when(this.shouldShowPropertySettings, () => html` <h3>Settings</h3>`)}
+        <div
+          class="slot-container"
+          style="${!this.shouldShowPropertySettings ? 'display: none' : ''}"
+          @slotchange=${this.handleSettingsSlotChange}
+        >
+          <slot name="settings"></slot>
+        </div>
       </div>
     `;
   }
@@ -124,7 +137,7 @@ import '${this.modulePath}';
     }
   }
 
-  private get demoUsage(): string {
+  private get exampleUsage(): string {
     return `<${this.elementTag}${this.stringifiedProps ?? ''}></${this.elementTag}>`;
   }
 
@@ -142,6 +155,12 @@ ${this.elementTag} {
     return this.labs
       ? `@internetarchive/elements/labs/${this.elementTag}/${this.elementTag}`
       : `@internetarchive/elements/${this.elementTag}/${this.elementTag}`;
+  }
+
+  /* Toggles visibility of section depending on whether inputs have been slotted into it */
+  private handleSettingsSlotChange(e: Event): void {
+    const slottedChildren = (e.target as HTMLSlotElement).assignedElements();
+    this.shouldShowPropertySettings = slottedChildren.length > 0;
   }
 
   /* Detects and stores a reference to slotted demo component */

--- a/demo/story-template.ts
+++ b/demo/story-template.ts
@@ -146,7 +146,7 @@ import '${this.modulePath}';
     return `
 
 ${this.elementTag} {
-  ${this.stringifiedStyles}
+ ${this.stringifiedStyles}
 }
     `;
   }

--- a/demo/story-template.ts
+++ b/demo/story-template.ts
@@ -191,9 +191,9 @@ ${this.elementTag} {
     if (!stringifiedProps || !appliedProps) return;
 
     this.stringifiedProps = stringifiedProps;
-    appliedProps.forEach((prop) =>
-      this.slottedDemoComponent?.setAttribute(prop.propName, prop.value),
-    );
+    appliedProps.forEach((prop) => {
+      this.slottedDemoComponent[prop.propName] = prop.value;
+    });
   }
 
   static get styles(): CSSResultGroup {

--- a/demo/story-template.ts
+++ b/demo/story-template.ts
@@ -93,9 +93,7 @@ export class StoryTemplate extends LitElement {
         <h3>Usage</h3>
         <syntax-highlighter
           language="auto"
-          .code=${this.customExampleUsage
-            ? this.customExampleUsage
-            : this.exampleUsage}
+          .code=${this.customExampleUsage ?? this.exampleUsage}
         ></syntax-highlighter>
         ${when(
           this.cssCode,
@@ -141,7 +139,11 @@ import '${this.modulePath}';
   }
 
   private get exampleUsage(): string {
-    return `<${this.elementTag}${this.defaultUsageProps ? '\n ' + this.defaultUsageProps + '\n' : ''}${this.stringifiedProps ?? ''}></${this.elementTag}>`;
+    const defaultProps = this.defaultUsageProps
+      ? '\n ' + this.defaultUsageProps + '\n'
+      : '';
+    const appliedProps = this.stringifiedProps ?? '';
+    return `<${this.elementTag}${defaultProps}${appliedProps}></${this.elementTag}>`;
   }
 
   private get cssCode(): string {

--- a/demo/story-utils.ts
+++ b/demo/story-utils.ts
@@ -1,0 +1,4 @@
+/* Converts a label to a usable input id, i.e. My setting -> my-setting */
+export function labelToId(label: string): string {
+  return label.toLowerCase().split(' ').join('-');
+}

--- a/src/elements/ia-button/ia-button-story.ts
+++ b/src/elements/ia-button/ia-button-story.ts
@@ -28,7 +28,7 @@ export class IAButtonStory extends LitElement {
       <story-template
         elementTag="ia-button"
         elementClassName="IAButton"
-        .customExampleUsage=${this.exampleUsage}
+        .defaultUsageProps=${`@click=\${() => alert('Button clicked!')}`}
         .styleInputData=${{ settings: styleInputSettings }}
       >
         <div slot="demo">
@@ -38,9 +38,5 @@ export class IAButtonStory extends LitElement {
         </div>
       </story-template>
     `;
-  }
-
-  private get exampleUsage(): string {
-    return `<ia-button @click=\${() => alert('Button clicked!')}>Click Me</ia-button>`;
   }
 }

--- a/src/elements/ia-button/ia-button-story.ts
+++ b/src/elements/ia-button/ia-button-story.ts
@@ -1,7 +1,7 @@
 import { html, LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
 
-import type { StyleInputSettings } from '@demo/story-template';
+import type { StyleInputSettings } from '@demo/story-components/story-styles-settings';
 
 import './ia-button';
 import '@demo/story-template';

--- a/src/elements/ia-button/ia-button-story.ts
+++ b/src/elements/ia-button/ia-button-story.ts
@@ -28,7 +28,7 @@ export class IAButtonStory extends LitElement {
       <story-template
         elementTag="ia-button"
         elementClassName="IAButton"
-        .exampleUsage=${this.exampleUsage}
+        .customExampleUsage=${this.exampleUsage}
         .styleInputData=${{ settings: styleInputSettings }}
       >
         <div slot="demo">

--- a/src/elements/ia-combo-box/ia-combo-box-story.ts
+++ b/src/elements/ia-combo-box/ia-combo-box-story.ts
@@ -1,6 +1,6 @@
 import { css, html, LitElement, type CSSResultGroup } from 'lit';
 import { customElement, state, query } from 'lit/decorators.js';
-import { StyleInputSettings } from '@demo/story-template';
+import { StyleInputSettings } from '@demo/story-components/story-styles-settings';
 import {
   IAComboBoxBehavior,
   IAComboBoxFilterOption,

--- a/src/elements/ia-combo-box/ia-combo-box-story.ts
+++ b/src/elements/ia-combo-box/ia-combo-box-story.ts
@@ -167,7 +167,7 @@ export class IAComboBoxStory extends LitElement {
       <story-template
         elementTag="ia-combo-box"
         elementClassName="IAComboBox"
-        .exampleUsage=${this.exampleUsage}
+        .customExampleUsage=${this.exampleUsage}
         .styleInputData=${{ settings: styleInputSettings }}
       >
         <div slot="demo">

--- a/src/elements/ia-status-indicator/ia-status-indicator-story.ts
+++ b/src/elements/ia-status-indicator/ia-status-indicator-story.ts
@@ -1,9 +1,9 @@
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
-import { PropInputSettings } from '@demo/story-template';
+import type { PropInputSettings } from '@demo/story-components/story-prop-settings';
 import type { StyleInputSettings } from '@demo/story-components/story-styles-settings';
-import { IAStatusIndicator } from './ia-status-indicator';
+import type { IAStatusIndicator } from './ia-status-indicator';
 
 import './ia-status-indicator';
 import '@demo/story-template';

--- a/src/elements/ia-status-indicator/ia-status-indicator-story.ts
+++ b/src/elements/ia-status-indicator/ia-status-indicator-story.ts
@@ -1,7 +1,8 @@
 import { html, LitElement } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 
-import { PropInputSettings, StyleInputSettings } from '@demo/story-template';
+import { PropInputSettings } from '@demo/story-template';
+import type { StyleInputSettings } from '@demo/story-components/story-styles-settings';
 import { IAStatusIndicator } from './ia-status-indicator';
 
 import './ia-status-indicator';

--- a/src/elements/ia-status-indicator/ia-status-indicator-story.ts
+++ b/src/elements/ia-status-indicator/ia-status-indicator-story.ts
@@ -1,5 +1,5 @@
 import { html, LitElement } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement } from 'lit/decorators.js';
 
 import type { PropInputSettings } from '@demo/story-components/story-prop-settings';
 import type { StyleInputSettings } from '@demo/story-components/story-styles-settings';
@@ -68,25 +68,16 @@ const propInputSettings: PropInputSettings<IAStatusIndicator>[] = [
 
 @customElement('ia-status-indicator-story')
 export class IAStatusIndicatorStory extends LitElement {
-  /* Applied properties fro the component in .myprop=${'foo'} format */
-  @state()
-  private stringifiedProps: string = '';
-
   render() {
     return html`
       <story-template
         elementTag="ia-status-indicator"
         elementClassName="IAStatusIndicator"
-        .exampleUsage=${this.exampleUsage}
         .styleInputData=${{ settings: styleInputSettings }}
         .propInputData=${{ settings: propInputSettings }}
       >
         <ia-status-indicator slot="demo"></ia-status-indicator>
       </story-template>
     `;
-  }
-
-  private get exampleUsage(): string {
-    return `<ia-status-indicator${this.stringifiedProps ?? ''}></ia-status-indicator>`;
   }
 }

--- a/src/elements/ia-status-indicator/ia-status-indicator-story.ts
+++ b/src/elements/ia-status-indicator/ia-status-indicator-story.ts
@@ -1,9 +1,7 @@
-import { html, LitElement, nothing, TemplateResult } from 'lit';
-import { customElement, query, queryAll, state } from 'lit/decorators.js';
-import { choose } from 'lit/directives/choose.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 
-import { StyleInputSettings } from '@demo/story-template';
+import { PropInputSettings, StyleInputSettings } from '@demo/story-template';
 import { IAStatusIndicator } from './ia-status-indicator';
 
 import './ia-status-indicator';
@@ -34,14 +32,6 @@ const styleInputSettings: StyleInputSettings[] = [
     inputType: 'color',
   },
 ];
-
-export type PropInputSettings<T> = {
-  label: string;
-  propertyName: keyof T;
-  defaultValue?: string;
-  inputType?: 'text' | 'radio';
-  radioOptions?: string[];
-};
 
 const propInputSettings: PropInputSettings<IAStatusIndicator>[] = [
   {
@@ -81,12 +71,6 @@ export class IAStatusIndicatorStory extends LitElement {
   @state()
   private stringifiedProps: string = '';
 
-  @query('ia-status-indicator')
-  private component!: IAStatusIndicator;
-
-  @queryAll('.prop-input')
-  private propInputs?: NodeListOf<HTMLInputElement>;
-
   render() {
     return html`
       <story-template
@@ -94,108 +78,14 @@ export class IAStatusIndicatorStory extends LitElement {
         elementClassName="IAStatusIndicator"
         .exampleUsage=${this.exampleUsage}
         .styleInputData=${{ settings: styleInputSettings }}
+        .propInputData=${{ settings: propInputSettings }}
       >
-        <div slot="demo">
-          <ia-status-indicator></ia-status-indicator>
-        </div>
-
-        <div slot="settings">
-          <table>
-            ${propInputSettings.map((inputSettings) =>
-              this.createPropInput(inputSettings),
-            )}
-          </table>
-          <button @click=${this.apply}>Apply</button>
-        </div>
+        <ia-status-indicator slot="demo"></ia-status-indicator>
       </story-template>
     `;
   }
 
   private get exampleUsage(): string {
     return `<ia-status-indicator${this.stringifiedProps ?? ''}></ia-status-indicator>`;
-  }
-
-  /* Creates a property input */
-  private createPropInput(
-    settings: PropInputSettings<IAStatusIndicator>,
-  ): TemplateResult | typeof nothing {
-    return (
-      choose(
-        settings.inputType,
-        [['radio', () => this.radioPropInputTemplate(settings)]],
-        () => this.defaultPropInputTemplate(settings),
-      ) ?? nothing
-    );
-  }
-
-  private defaultPropInputTemplate(
-    settings: PropInputSettings<IAStatusIndicator>,
-  ): TemplateResult {
-    const inputId = settings.label.toLowerCase().split(' ').join('-');
-
-    return html`
-      <tr>
-        <td><label for=${inputId}>${settings.label}</label></td>
-        <td>
-          <input
-            class="prop-input"
-            type=${settings.inputType ?? 'text'}
-            id=${inputId}
-            data-prop=${settings.propertyName}
-            placeholder=${ifDefined(settings?.defaultValue)}
-          />
-        </td>
-      </tr>
-    `;
-  }
-
-  /* Generator for a radio prop input, including the associated label text */
-  private radioPropInputTemplate(
-    settings: PropInputSettings<IAStatusIndicator>,
-  ): TemplateResult | typeof nothing {
-    if (settings.inputType !== 'radio' || !settings.radioOptions)
-      return nothing;
-
-    const inputId = settings.label.toLowerCase().split(' ').join('-');
-
-    return html`
-      <tr>
-        <td><legend>${settings.label}</legend></td>
-        <td>
-          ${settings.radioOptions.map(
-            (option) =>
-              html`<input
-                  type="radio"
-                  class="prop-input"
-                  name=${inputId}
-                  id=${option}
-                  value=${option}
-                  data-prop=${settings.propertyName}
-                  ?checked=${settings.defaultValue === option}
-                /><label for=${option}> ${option} </label>`,
-          )}
-        </td>
-      </tr>
-    `;
-  }
-
-  private apply() {
-    const appliedProps: string[] = [];
-    this.propInputs?.forEach((input) => {
-      if (
-        !input.dataset.prop ||
-        !input.value ||
-        (input.type === 'radio' && !input.checked)
-      )
-        return;
-
-      const prop = input.dataset.prop;
-      appliedProps.push(`.${prop}=\${'${input.value}'}`);
-      this.component.setAttribute(prop, input.value);
-    });
-
-    if (!appliedProps.length) return;
-
-    this.stringifiedProps = '\n  ' + appliedProps.join('\n  ') + '\n';
   }
 }

--- a/src/labs/ia-snow/ia-snow-story.ts
+++ b/src/labs/ia-snow/ia-snow-story.ts
@@ -26,7 +26,7 @@ export class IASnowStory extends LitElement {
       <story-template
         elementTag="ia-snow"
         elementClassName="IASnow"
-        .exampleUsage=${this.exampleUsage}
+        .customExampleUsage=${this.exampleUsage}
         labs
       >
         <div slot="demo">


### PR DESCRIPTION
Encapsulates property settings for easy reuse, which can be extended gradually to be used for i.e. `ia-combo-box` and other more complicated components.

Also extracts property settings and style settings out of the `story-template` and encapsulates `exampleUsage` inside template (with the option to override)