### PR TITLE
WEBDEV-8327 Add basic OTP input

### DIFF
--- a/demo/story-components/story-prop-settings.ts
+++ b/demo/story-components/story-prop-settings.ts
@@ -132,7 +132,7 @@ export class StoryPropsSettings extends LitElement {
       if (value === 'false') value = false;
 
       const stringifiedValue =
-        typeof value === 'string' ? `'${value}` : value.toString();
+        typeof value === 'string' ? `'${value}'` : value.toString();
       stringifiedProps.push(`.${propName}=\${${stringifiedValue}}`);
       appliedProps.push({ propName, value });
     });

--- a/demo/story-components/story-prop-settings.ts
+++ b/demo/story-components/story-prop-settings.ts
@@ -9,7 +9,6 @@ import {
 import { property, queryAll } from 'lit/decorators.js';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { choose } from 'lit/directives/choose.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
 
 import themeStyles from '@src/themes/theme-styles';
 import { labelToId } from '../story-utils';
@@ -17,7 +16,7 @@ import { labelToId } from '../story-utils';
 export type PropInputSettings<T> = {
   label: string;
   propertyName: keyof T;
-  defaultValue?: string | boolean | number;
+  defaultValue: string | boolean | number;
   inputType?: 'text' | 'radio' | 'number';
   radioOptions?: string[] | boolean[];
 };
@@ -76,7 +75,7 @@ export class StoryPropsSettings extends LitElement {
             id=${inputId}
             data-prop=${settings.propertyName}
             data-format=${typeof settings.defaultValue}
-            placeholder=${ifDefined(settings?.defaultValue)}
+            placeholder=${settings.defaultValue}
           />
         </td>
       </tr>

--- a/demo/story-components/story-prop-settings.ts
+++ b/demo/story-components/story-prop-settings.ts
@@ -75,6 +75,7 @@ export class StoryPropsSettings extends LitElement {
             type=${settings.inputType ?? 'text'}
             id=${inputId}
             data-prop=${settings.propertyName}
+            data-format=${typeof settings.defaultValue}
             placeholder=${ifDefined(settings?.defaultValue)}
           />
         </td>
@@ -103,6 +104,7 @@ export class StoryPropsSettings extends LitElement {
                   id="${inputId}-${option}"
                   value=${option}
                   data-prop=${settings.propertyName}
+                  data-format=${typeof settings.defaultValue}
                   ?checked=${settings.defaultValue === option}
                 /><label for="${inputId}-${option}"> ${option} </label>`,
           )}
@@ -127,9 +129,15 @@ export class StoryPropsSettings extends LitElement {
       let value: number | string | boolean = input.value;
 
       // Perform necessary conversions for props to apply
-      if (input.type === 'number') value = parseInt(value);
-      if (value === 'true') value = true;
-      if (value === 'false') value = false;
+      switch (input.dataset.format) {
+        case 'number':
+          value = parseInt(value);
+          break;
+        case 'boolean':
+          if (value === 'true') value = true;
+          if (value === 'false') value = false;
+          break;
+      }
 
       const stringifiedValue =
         typeof value === 'string' ? `'${value}'` : value.toString();

--- a/demo/story-components/story-prop-settings.ts
+++ b/demo/story-components/story-prop-settings.ts
@@ -17,9 +17,9 @@ import { labelToId } from '../story-utils';
 export type PropInputSettings<T> = {
   label: string;
   propertyName: keyof T;
-  defaultValue?: string;
-  inputType?: 'text' | 'radio';
-  radioOptions?: string[];
+  defaultValue?: string | boolean | number;
+  inputType?: 'text' | 'radio' | 'number';
+  radioOptions?: string[] | boolean[];
 };
 
 export type PropInputData = {
@@ -124,8 +124,17 @@ export class StoryPropsSettings extends LitElement {
         return;
 
       const propName = input.dataset.prop;
-      stringifiedProps.push(`.${propName}=\${'${input.value}'}`);
-      appliedProps.push({ propName, value: input.value });
+      let value: number | string | boolean = input.value;
+
+      // Perform necessary conversions for props to apply
+      if (input.type === 'number') value = parseInt(value);
+      if (value === 'true') value = true;
+      if (value === 'false') value = false;
+
+      const stringifiedValue =
+        typeof value === 'string' ? `'${value}` : value.toString();
+      stringifiedProps.push(`.${propName}=\${${stringifiedValue}}`);
+      appliedProps.push({ propName, value });
     });
 
     this.dispatchEvent(

--- a/demo/story-template.ts
+++ b/demo/story-template.ts
@@ -79,15 +79,18 @@ export class StoryTemplate extends LitElement {
           ></slot>
         </div>
         <button
-          class="details-toggle ${this.detailsVisible ? 'expanded' : 'collapsed'}"
+          class="details-toggle ${this.detailsVisible
+            ? 'expanded'
+            : 'collapsed'}"
           @click=${() => (this.detailsVisible = !this.detailsVisible)}
         >
           Import, Usage &amp; Settings
         </button>
-        <div id="details" class="${this.detailsVisible ? 'expanded' : 'collapsed'}">
-          <div class="details-inner">
-            ${this.detailsTemplate}
-          </div>
+        <div
+          id="details"
+          class="${this.detailsVisible ? 'expanded' : 'collapsed'}"
+        >
+          <div class="details-inner">${this.detailsTemplate}</div>
         </div>
       </div>
     `;
@@ -95,93 +98,94 @@ export class StoryTemplate extends LitElement {
 
   private get detailsTemplate() {
     return html`
-        <h3>
-          Import
-          <button
-            class="copy-btn ${this.copiedKey === 'import' ? 'copied' : ''}"
-            @click=${() => this.copyToClipboard(this.importCode, 'import')}
-          >
-            ${this.copiedKey === 'import' ? 'Copied!' : 'Copy'}
-          </button>
-        </h3>
-        <syntax-highlighter
-          language="typescript"
-          .code=${this.importCode}
-        ></syntax-highlighter>
-        <h3>
-          Usage
-          <button
-            class="copy-btn ${this.copiedKey === 'usage' ? 'copied' : ''}"
-            @click=${() =>
-              this.copyToClipboard(
-                this.customExampleUsage ?? this.exampleUsage,
-                'usage',
-              )}
-          >
-            ${this.copiedKey === 'usage' ? 'Copied!' : 'Copy'}
-          </button>
-        </h3>
-        <syntax-highlighter
-          language="auto"
-          .code=${this.customExampleUsage ?? this.exampleUsage}
-        ></syntax-highlighter>
-        ${when(
-          this.cssCode,
-          () => html`
-            <h3>
-              Styling
-              <button
-                class="copy-btn ${this.copiedKey === 'styling' ? 'copied' : ''}"
-                @click=${() => this.copyToClipboard(this.cssCode, 'styling')}
-              >
-                ${this.copiedKey === 'styling' ? 'Copied!' : 'Copy'}
-              </button>
-            </h3>
-            <syntax-highlighter
-              language="css"
-              .code=${this.cssCode}
-            ></syntax-highlighter>
-          `,
-        )}
-        <div class="two-col">
-          <div class="left-col">
-            <h3>Settings</h3>
-            ${when(
-              !!this.propInputData,
-              () => html`
-                <story-props-settings
-                  .propInputData=${this.propInputData}
-                  @propsApplied=${this.handlePropsApplied}
-                ></story-props-settings>
-              `,
+      <h3>
+        Import
+        <button
+          class="copy-btn ${this.copiedKey === 'import' ? 'copied' : ''}"
+          @click=${() => this.copyToClipboard(this.importCode, 'import')}
+        >
+          ${this.copiedKey === 'import' ? 'Copied!' : 'Copy'}
+        </button>
+      </h3>
+      <syntax-highlighter
+        language="typescript"
+        .code=${this.importCode}
+      ></syntax-highlighter>
+      <h3>
+        Usage
+        <button
+          class="copy-btn ${this.copiedKey === 'usage' ? 'copied' : ''}"
+          @click=${() =>
+            this.copyToClipboard(
+              this.customExampleUsage ?? this.exampleUsage,
+              'usage',
             )}
-            ${when(
-              !this.propInputData && !this.shouldShowPropertySettings,
-              () =>
-                html`<p class="section-placeholder">No settings to adjust</p>`,
-            )}
-            <div
-              class="slot-container ${this.shouldShowPropertySettings ? '' : 'hidden'}"
-              @slotchange=${this.handleSettingsSlotChange}
+        >
+          ${this.copiedKey === 'usage' ? 'Copied!' : 'Copy'}
+        </button>
+      </h3>
+      <syntax-highlighter
+        language="auto"
+        .code=${this.customExampleUsage ?? this.exampleUsage}
+      ></syntax-highlighter>
+      ${when(
+        this.cssCode,
+        () => html`
+          <h3>
+            Styling
+            <button
+              class="copy-btn ${this.copiedKey === 'styling' ? 'copied' : ''}"
+              @click=${() => this.copyToClipboard(this.cssCode, 'styling')}
             >
-              <slot name="settings"></slot>
-            </div>
-          </div>
-          <div class="right-col">
-            <h3>Styles</h3>
-            ${when(
-              !!this.styleInputData,
-              () => html`
-                <story-styles-settings
-                  .styleInputData=${this.styleInputData}
-                  @stylesApplied=${this.handleStylesApplied}
-                ></story-styles-settings>
-              `,
-              () =>
-                html`<p class="section-placeholder">No styles to adjust</p>`,
-            )}
+              ${this.copiedKey === 'styling' ? 'Copied!' : 'Copy'}
+            </button>
+          </h3>
+          <syntax-highlighter
+            language="css"
+            .code=${this.cssCode}
+          ></syntax-highlighter>
+        `,
+      )}
+      <div class="two-col">
+        <div class="left-col">
+          <h3>Settings</h3>
+          ${when(
+            !!this.propInputData,
+            () => html`
+              <story-props-settings
+                .propInputData=${this.propInputData}
+                @propsApplied=${this.handlePropsApplied}
+              ></story-props-settings>
+            `,
+          )}
+          ${when(
+            !this.propInputData && !this.shouldShowPropertySettings,
+            () =>
+              html`<p class="section-placeholder">No settings to adjust</p>`,
+          )}
+          <div
+            class="slot-container ${this.shouldShowPropertySettings
+              ? ''
+              : 'hidden'}"
+            @slotchange=${this.handleSettingsSlotChange}
+          >
+            <slot name="settings"></slot>
           </div>
         </div>
+        <div class="right-col">
+          <h3>Styles</h3>
+          ${when(
+            !!this.styleInputData,
+            () => html`
+              <story-styles-settings
+                .styleInputData=${this.styleInputData}
+                @stylesApplied=${this.handleStylesApplied}
+              ></story-styles-settings>
+            `,
+            () => html`<p class="section-placeholder">No styles to adjust</p>`,
+          )}
+        </div>
+      </div>
     `;
   }
 

--- a/src/elements/ia-otp-input/ia-otp-input-story.ts
+++ b/src/elements/ia-otp-input/ia-otp-input-story.ts
@@ -1,0 +1,68 @@
+import { html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import type { PropInputSettings } from '@demo/story-components/story-prop-settings';
+import type { StyleInputSettings } from '@demo/story-components/story-styles-settings';
+import type { IAOTPInput } from './ia-otp-input';
+
+import './ia-otp-input';
+import '@demo/story-template';
+
+const styleInputSettings: StyleInputSettings[] = [
+  {
+    label: 'Text color',
+    cssVariable: '--ia-theme-primary-text-color',
+    defaultValue: '#2c2c2c',
+    inputType: 'color',
+  },
+  {
+    label: 'Font size',
+    cssVariable: '--ia-theme-font-size-lg',
+    defaultValue: '2.25rem',
+    inputType: 'text',
+  },
+];
+
+const propInputSettings: PropInputSettings<IAOTPInput>[] = [
+  {
+    label: 'Number of characters',
+    propertyName: 'numChars',
+    defaultValue: 6,
+    inputType: 'number',
+  },
+  {
+    label: 'Numeric only',
+    propertyName: 'numericOnly',
+    defaultValue: true,
+    inputType: 'radio',
+    radioOptions: [true, false],
+  },
+  {
+    label: 'Prefill value',
+    propertyName: 'prefillValue',
+    defaultValue: '',
+  },
+  {
+    label: 'Disabled',
+    propertyName: 'disabled',
+    defaultValue: false,
+    inputType: 'radio',
+    radioOptions: [true, false],
+  },
+];
+
+@customElement('ia-otp-input-story')
+export class IAOTPInputStory extends LitElement {
+  render() {
+    return html`
+      <story-template
+        elementTag="ia-otp-input"
+        elementClassName="IAOTPInput"
+        .styleInputData=${{ settings: styleInputSettings }}
+        .propInputData=${{ settings: propInputSettings }}
+      >
+        <ia-otp-input slot="demo"></ia-otp-input>
+      </story-template>
+    `;
+  }
+}

--- a/src/elements/ia-otp-input/ia-otp-input.test.ts
+++ b/src/elements/ia-otp-input/ia-otp-input.test.ts
@@ -1,0 +1,587 @@
+import { fixture, oneEvent } from '@open-wc/testing-helpers';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { html } from 'lit';
+
+import { IAOTPInput } from './ia-otp-input';
+import './ia-otp-input';
+
+describe('IA OTP Input', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('renders 6 inputs by default', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    expect(inputs?.length).to.equal(6);
+  });
+
+  test('renders more inputs if requested', async () => {
+    const el = await fixture<IAOTPInput>(
+      html`<ia-otp-input .numChars=${10}></ia-otp-input>`,
+    );
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    expect(inputs?.length).to.equal(10);
+  });
+
+  test('adds the one-time-passcode autocomplete attribute to only the first input', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    expect(inputs?.[0].autocomplete).to.equal('one-time-code');
+    expect(inputs?.[1].autocomplete).to.equal('off');
+  });
+
+  test('uses numeric keyboard by default', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    expect(inputs?.[0].inputMode).to.equal('numeric');
+  });
+
+  test('uses regular keyboard if other characters allowed', async () => {
+    const el = await fixture<IAOTPInput>(
+      html`<ia-otp-input .numericOnly=${false}></ia-otp-input>`,
+    );
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    expect(inputs?.[0].inputMode).to.equal('text');
+  });
+
+  test('shifts focus to next input if character entered', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    const firstInput = inputs?.[0] as HTMLInputElement;
+    const secondInput = inputs?.[1] as HTMLInputElement;
+    const focusSpy = vi
+      .spyOn(secondInput, 'focus')
+      .mockResolvedValue(undefined)
+      .mockResolvedValue(undefined);
+
+    firstInput.dispatchEvent(new InputEvent('beforeinput', { data: '1' }));
+
+    expect(firstInput.value).to.equal('1');
+    expect(focusSpy).toHaveBeenCalledOnce();
+  });
+
+  test('shifts focus as usual if falsey number like 0 entered', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    const firstInput = inputs?.[0] as HTMLInputElement;
+    const secondInput = inputs?.[1] as HTMLInputElement;
+    const focusSpy = vi
+      .spyOn(secondInput, 'focus')
+      .mockResolvedValue(undefined);
+
+    firstInput.dispatchEvent(new InputEvent('beforeinput', { data: '0' }));
+
+    expect(firstInput.value).to.equal('0');
+    expect(focusSpy).toHaveBeenCalledOnce();
+  });
+
+  test('does not allow non-alphanumeric entry', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    const firstInput = inputs?.[0] as HTMLInputElement;
+    const secondInput = inputs?.[1] as HTMLInputElement;
+    const focusSpy = vi
+      .spyOn(secondInput, 'focus')
+      .mockResolvedValue(undefined);
+
+    firstInput.dispatchEvent(new InputEvent('beforeinput', { data: ' ' }));
+
+    expect(firstInput.value).to.equal('');
+    expect(focusSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test('does not allow non-numeric entry by default', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    const firstInput = inputs?.[0] as HTMLInputElement;
+    const secondInput = inputs?.[1] as HTMLInputElement;
+    const focusSpy = vi
+      .spyOn(secondInput, 'focus')
+      .mockResolvedValue(undefined);
+
+    firstInput.dispatchEvent(new InputEvent('beforeinput', { data: 'A' }));
+
+    expect(firstInput.value).to.equal('');
+    expect(focusSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test('does allow letter input if numericOnly is false', async () => {
+    const el = await fixture<IAOTPInput>(
+      html`<ia-otp-input .numericOnly=${false}></ia-otp-input>`,
+    );
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    const firstInput = inputs?.[0] as HTMLInputElement;
+    const secondInput = inputs?.[1] as HTMLInputElement;
+    const focusSpy = vi
+      .spyOn(secondInput, 'focus')
+      .mockResolvedValue(undefined);
+
+    firstInput.dispatchEvent(new InputEvent('beforeinput', { data: 'A' }));
+
+    expect(firstInput.value).to.equal('A');
+    expect(focusSpy).toHaveBeenCalledOnce();
+  });
+
+  test('replaces existing character with new character on input', async () => {
+    const el = await fixture<IAOTPInput>(
+      html`<ia-otp-input .numericOnly=${false}></ia-otp-input>`,
+    );
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    const firstInput = inputs?.[0] as HTMLInputElement;
+    const secondInput = inputs?.[1] as HTMLInputElement;
+    const focusSpy = vi
+      .spyOn(secondInput, 'focus')
+      .mockResolvedValue(undefined);
+
+    firstInput.value = 'A';
+    firstInput.dispatchEvent(new InputEvent('beforeinput', { data: 'B' }));
+
+    expect(firstInput.value).to.equal('B');
+    expect(focusSpy).toHaveBeenCalledOnce();
+  });
+
+  test('does not replace existing character with new character if invalid second char entered', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    const firstInput = inputs?.[0] as HTMLInputElement;
+    const secondInput = inputs?.[1] as HTMLInputElement;
+    const focusSpy = vi
+      .spyOn(secondInput, 'focus')
+      .mockResolvedValue(undefined);
+
+    firstInput.value = '1';
+    firstInput.dispatchEvent(new InputEvent('beforeinput', { data: 'B' }));
+
+    expect(firstInput.value).to.equal('1');
+    expect(focusSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test('does not shift focus if value is empty', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    const firstInput = inputs?.[0] as HTMLInputElement;
+    const secondInput = inputs?.[1] as HTMLInputElement;
+    const focusSpy = vi
+      .spyOn(secondInput, 'focus')
+      .mockResolvedValue(undefined);
+
+    firstInput.dispatchEvent(new InputEvent('beforeinput', { data: '' }));
+
+    expect(focusSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test('shifts focus backwards if backspace entered', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    const firstInput = inputs?.[0] as HTMLInputElement;
+    const secondInput = inputs?.[1] as HTMLInputElement;
+    const focusSpy = vi.spyOn(firstInput, 'focus').mockResolvedValue(undefined);
+
+    const backspaceEvent = new KeyboardEvent('keydown', {
+      code: 'Backspace',
+      key: 'Backspace',
+      charCode: 8,
+      keyCode: 8,
+      view: window,
+      bubbles: true,
+    });
+    secondInput.dispatchEvent(backspaceEvent);
+
+    expect(focusSpy).toHaveBeenCalledOnce();
+  });
+
+  test('shifts focus backwards if delete entered', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    const firstInput = inputs?.[0] as HTMLInputElement;
+    const secondInput = inputs?.[1] as HTMLInputElement;
+    const focusSpy = vi.spyOn(firstInput, 'focus').mockResolvedValue(undefined);
+
+    const backspaceEvent = new KeyboardEvent('keydown', {
+      code: 'Delete',
+      key: 'Delete',
+      charCode: 46,
+      keyCode: 46,
+      view: window,
+      bubbles: true,
+    });
+    secondInput.dispatchEvent(backspaceEvent);
+
+    expect(focusSpy).toHaveBeenCalledOnce();
+  });
+
+  test('deletes only focused char if input filled and delete entered', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    const firstInput = inputs?.[0] as HTMLInputElement;
+    const secondInput = inputs?.[1] as HTMLInputElement;
+
+    firstInput.value = '1';
+    secondInput.value = '2';
+    const backspaceEvent = new KeyboardEvent('keydown', {
+      code: 'Delete',
+      key: 'Delete',
+      charCode: 46,
+      keyCode: 46,
+      view: window,
+      bubbles: true,
+    });
+    secondInput.dispatchEvent(backspaceEvent);
+
+    expect(secondInput.value).to.equal('');
+    expect(firstInput.value).to.equal('1');
+  });
+
+  test('deletes previous char if input not filled and delete entered', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    const firstInput = inputs?.[0] as HTMLInputElement;
+    const secondInput = inputs?.[1] as HTMLInputElement;
+
+    firstInput.value = '1';
+    secondInput.value = '';
+    const backspaceEvent = new KeyboardEvent('keydown', {
+      code: 'Delete',
+      key: 'Delete',
+      charCode: 46,
+      keyCode: 46,
+      view: window,
+      bubbles: true,
+    });
+    secondInput.dispatchEvent(backspaceEvent);
+
+    expect(secondInput.value).to.equal('');
+    expect(firstInput.value).to.equal('');
+  });
+
+  test('shifts focus forwards and selects existing value if tab entered', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    const firstInput = inputs?.[0] as HTMLInputElement;
+    const selectSpy = vi
+      .spyOn(firstInput, 'select')
+      .mockResolvedValue(undefined);
+
+    const tabEvent = new KeyboardEvent('keydown', {
+      code: 'Tab',
+      key: 'Tab',
+      charCode: 9,
+      keyCode: 9,
+      view: window,
+      bubbles: true,
+    });
+    firstInput.dispatchEvent(tabEvent);
+
+    expect(selectSpy).toHaveBeenCalledOnce();
+  });
+
+  test('shifts focus forwards if right arrow entered', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    const firstInput = inputs?.[0];
+    const secondInput = inputs?.[1] as HTMLInputElement;
+    const focusSpy = vi
+      .spyOn(secondInput, 'focus')
+      .mockResolvedValue(undefined);
+
+    const arrowEvent = new KeyboardEvent('keydown', {
+      code: 'ArrowRight',
+      key: 'ArrowRight',
+      charCode: 39,
+      keyCode: 39,
+      view: window,
+      bubbles: true,
+    });
+    firstInput?.dispatchEvent(arrowEvent);
+
+    expect(focusSpy).toHaveBeenCalledOnce();
+  });
+
+  test('shifts focus backwards if left arrow entered', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    const firstInput = inputs?.[0] as HTMLInputElement;
+    const secondInput = inputs?.[1] as HTMLInputElement;
+    const focusSpy = vi.spyOn(firstInput, 'focus').mockResolvedValue(undefined);
+
+    const arrowEvent = new KeyboardEvent('keydown', {
+      code: 'ArrowLeft',
+      key: 'ArrowLeft',
+      charCode: 37,
+      keyCode: 37,
+      view: window,
+      bubbles: true,
+    });
+    secondInput?.dispatchEvent(arrowEvent);
+
+    expect(focusSpy).toHaveBeenCalledOnce();
+  });
+
+  test('fills as many inputs as possible if content is pasted', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    const firstInput = inputs?.[0] as HTMLInputElement;
+
+    const pastedData = new DataTransfer();
+    pastedData.setData('text/plain', '12345');
+
+    firstInput.dispatchEvent(
+      new ClipboardEvent('paste', { clipboardData: pastedData }),
+    );
+
+    expect(firstInput.value).to.equal('1');
+    expect(inputs?.[1].value).to.equal('2');
+    expect(inputs?.[2].value).to.equal('3');
+    expect(inputs?.[3].value).to.equal('4');
+    expect(inputs?.[4].value).to.equal('5');
+    expect(inputs?.[5].value).to.equal('');
+  });
+
+  test('fills as many inputs as possible if multiple characters are inputted (i.e. autofilled) into first input', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    const firstInput = inputs?.[0] as HTMLInputElement;
+
+    firstInput.dispatchEvent(new InputEvent('beforeinput', { data: '12345' }));
+
+    expect(firstInput.value).to.equal('1');
+    expect(inputs?.[1].value).to.equal('2');
+    expect(inputs?.[2].value).to.equal('3');
+    expect(inputs?.[3].value).to.equal('4');
+    expect(inputs?.[4].value).to.equal('5');
+    expect(inputs?.[5].value).to.equal('');
+  });
+
+  test('shifts focus as usual following paste', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    const firstInput = inputs?.[0] as HTMLInputElement;
+    const focusSpy = vi
+      .spyOn(inputs?.[5] as HTMLInputElement, 'focus')
+      .mockResolvedValue(undefined);
+
+    const pastedData = new DataTransfer();
+    pastedData.setData('text/plain', '12345');
+
+    firstInput.dispatchEvent(
+      new ClipboardEvent('paste', { clipboardData: pastedData }),
+    );
+
+    expect(inputs?.[5].value).to.equal('');
+    expect(focusSpy).toHaveBeenCalledOnce();
+  });
+
+  test('overrides existing values on paste', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    const secondInput = inputs?.[1] as HTMLInputElement;
+
+    (inputs?.[4] as HTMLInputElement).value = '8';
+
+    const pastedData = new DataTransfer();
+    pastedData.setData('text/plain', '12345');
+
+    secondInput.dispatchEvent(
+      new ClipboardEvent('paste', { clipboardData: pastedData }),
+    );
+
+    expect(inputs?.[4].value).to.equal('5');
+  });
+
+  test('ignores any non-alphanumeric characters on paste', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    const firstInput = inputs?.[0] as HTMLInputElement;
+
+    const pastedData = new DataTransfer();
+    pastedData.setData('text/plain', '123*&4(( _5');
+
+    firstInput.dispatchEvent(
+      new ClipboardEvent('paste', { clipboardData: pastedData }),
+    );
+
+    expect(firstInput.value).to.equal('1');
+    expect(inputs?.[1].value).to.equal('2');
+    expect(inputs?.[2].value).to.equal('3');
+    expect(inputs?.[3].value).to.equal('4');
+    expect(inputs?.[4].value).to.equal('5');
+    expect(inputs?.[5].value).to.equal('');
+  });
+
+  test('triggers submission if all inputs filled by paste', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    const firstInput = inputs?.[0] as HTMLInputElement;
+
+    const pastedData = new DataTransfer();
+    pastedData.setData('text/plain', '123456');
+
+    const eventPromise = oneEvent(el, 'codeSubmitted');
+
+    firstInput.dispatchEvent(
+      new ClipboardEvent('paste', { clipboardData: pastedData }),
+    );
+
+    const { detail } = await eventPromise;
+    expect(detail).to.equal('123456');
+  });
+
+  test('triggers submission if all inputs filled by paste, plus extra digits', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    const firstInput = inputs?.[0] as HTMLInputElement;
+
+    const pastedData = new DataTransfer();
+    pastedData.setData('text/plain', '1234569273192756123');
+
+    const eventPromise = oneEvent(el, 'codeSubmitted');
+
+    firstInput.dispatchEvent(
+      new ClipboardEvent('paste', { clipboardData: pastedData }),
+    );
+
+    const { detail } = await eventPromise;
+    expect(detail).to.equal('123456');
+  });
+
+  test('triggers submission if all inputs filled manually', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const submitFn = vi.fn(() => undefined);
+    el.addEventListener('codeSubmitted', submitFn);
+    const eventPromise = oneEvent(el, 'codeSubmitted');
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    inputs?.forEach((input) => {
+      input.dispatchEvent(new InputEvent('beforeinput', { data: '0' }));
+    });
+
+    const { detail } = await eventPromise;
+    expect(detail).to.equal('000000');
+    expect(submitFn).toHaveBeenCalledOnce();
+  });
+
+  test('does not trigger submission if not all inputs filled', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+
+    const submitFn = vi.fn(() => undefined);
+    el.addEventListener('codeSubmitted', submitFn);
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    inputs?.forEach((input) => {
+      if (!input.id.includes('3')) {
+        input.value = '0';
+        input.dispatchEvent(new InputEvent('beforeinput', { data: '0' }));
+      }
+    });
+
+    expect(submitFn).toHaveBeenCalledTimes(0);
+  });
+
+  test('supports clearing all inputs via prefill value property', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    inputs?.forEach((input) => {
+      input.value = '1';
+    });
+
+    el.prefillValue = '';
+    await el.updateComplete;
+
+    expect(inputs?.[0].value).to.equal('');
+    expect(inputs?.[1].value).to.equal('');
+    expect(inputs?.[2].value).to.equal('');
+    expect(inputs?.[3].value).to.equal('');
+    expect(inputs?.[4].value).to.equal('');
+    expect(inputs?.[5].value).to.equal('');
+  });
+
+  test('supports filling multiple inputs via prefill value property', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    el.prefillValue = '23456';
+    await el.updateComplete;
+
+    expect(inputs?.[0].value).to.equal('2');
+    expect(inputs?.[1].value).to.equal('3');
+    expect(inputs?.[2].value).to.equal('4');
+    expect(inputs?.[3].value).to.equal('5');
+    expect(inputs?.[4].value).to.equal('6');
+    expect(inputs?.[5].value).to.equal('');
+  });
+
+  test('returns focus to first character if inputs cleared', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    inputs?.forEach((input) => {
+      input.value = '1';
+    });
+
+    const firstInput = inputs?.[0] as HTMLInputElement;
+    const focusSpy = vi.spyOn(firstInput, 'focus').mockResolvedValue(undefined);
+
+    el.prefillValue = '';
+    await el.updateComplete;
+
+    expect(focusSpy).toHaveBeenCalledOnce();
+  });
+
+  test('supports disabling of inputs via disabled property', async () => {
+    const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+
+    el.disabled = true;
+    await el.updateComplete;
+
+    expect(inputs?.[0].disabled).to.be.true;
+    expect(inputs?.[1].disabled).to.be.true;
+    expect(inputs?.[2].disabled).to.be.true;
+    expect(inputs?.[3].disabled).to.be.true;
+    expect(inputs?.[4].disabled).to.be.true;
+    expect(inputs?.[5].disabled).to.be.true;
+  });
+});

--- a/src/elements/ia-otp-input/ia-otp-input.test.ts
+++ b/src/elements/ia-otp-input/ia-otp-input.test.ts
@@ -487,6 +487,27 @@ describe('IA OTP Input', () => {
     expect(detail).to.equal('123456');
   });
 
+  test('capitalizes all characters on submit if alphanumeric allowed', async () => {
+    const el = await fixture<IAOTPInput>(
+      html`<ia-otp-input .numericOnly=${false}></ia-otp-input>`,
+    );
+
+    const inputs = el.shadowRoot?.querySelectorAll('input');
+    const firstInput = inputs?.[0] as HTMLInputElement;
+
+    const pastedData = new DataTransfer();
+    pastedData.setData('text/plain', '1a3B56');
+
+    const eventPromise = oneEvent(el, 'codeSubmitted');
+
+    firstInput.dispatchEvent(
+      new ClipboardEvent('paste', { clipboardData: pastedData }),
+    );
+
+    const { detail } = await eventPromise;
+    expect(detail).to.equal('1A3B56');
+  });
+
   test('triggers submission if all inputs filled manually', async () => {
     const el = await fixture<IAOTPInput>(html`<ia-otp-input></ia-otp-input>`);
 

--- a/src/elements/ia-otp-input/ia-otp-input.ts
+++ b/src/elements/ia-otp-input/ia-otp-input.ts
@@ -7,6 +7,7 @@ import {
   PropertyValues,
 } from 'lit';
 import { property, customElement, queryAll } from 'lit/decorators.js';
+import themeStyles from '@src/themes/theme-styles';
 
 /**
  * Custom event options for the component
@@ -55,6 +56,7 @@ export class IAOTPInput extends LitElement {
         (i) =>
           html`<input
             id="OTP-input-${i}"
+            part="input"
             type="text"
             autocomplete=${i === 0 ? 'one-time-code' : 'off'}
             inputmode=${this.numericOnly ? 'numeric' : 'text'}
@@ -201,23 +203,32 @@ export class IAOTPInput extends LitElement {
   }
 
   static get styles(): CSSResultGroup {
-    return css`
-      :host {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: nowrap;
-        gap: 5px;
-      }
+    return [
+      themeStyles,
+      css`
+        :host {
+          --primary-text-color--: var(--primary-text-color);
+          --font-size-lg--: var(--font-size-lg);
+        }
 
-      input {
-        font-size: 36px;
-        font-weight: bold;
-        width: 36px;
-        height: 56px;
-        text-align: center;
-        text-transform: uppercase;
-        padding: 0;
-      }
-    `;
+        :host {
+          display: flex;
+          flex-direction: row;
+          flex-wrap: nowrap;
+          gap: 5px;
+        }
+
+        input {
+          color: var(--primary-text-color--);
+          font-size: var(--font-size-lg--);
+          width: var(--font-size-lg--);
+          font-weight: bold;
+          height: calc(var(--font-size-lg--) + 1.25rem);
+          text-align: center;
+          text-transform: uppercase;
+          padding: 0;
+        }
+      `,
+    ];
   }
 }

--- a/src/elements/ia-otp-input/ia-otp-input.ts
+++ b/src/elements/ia-otp-input/ia-otp-input.ts
@@ -8,6 +8,13 @@ import {
 } from 'lit';
 import { property, customElement, queryAll } from 'lit/decorators.js';
 
+/**
+ * Custom event options for the component
+ */
+const Events = {
+  CodeSubmitted: 'codeSubmitted',
+};
+
 const NUMERIC_REGEX = /^[0-9]+$/;
 const ALPHANUMERIC_REGEX = /^[a-zA-Z0-9]+$/;
 
@@ -185,7 +192,7 @@ export class IAOTPInput extends LitElement {
   /* Submits code */
   private triggerSubmit(code: string): void {
     this.dispatchEvent(
-      new CustomEvent('codeSubmitted', {
+      new CustomEvent(Events.CodeSubmitted, {
         detail: code,
         bubbles: true,
         composed: true,

--- a/src/elements/ia-otp-input/ia-otp-input.ts
+++ b/src/elements/ia-otp-input/ia-otp-input.ts
@@ -197,7 +197,7 @@ export class IAOTPInput extends LitElement {
   private triggerSubmit(code: string): void {
     this.dispatchEvent(
       new CustomEvent(Events.CodeSubmitted, {
-        detail: code,
+        detail: this.numericOnly ? code : code.toUpperCase(),
         bubbles: true,
         composed: true,
       }),

--- a/src/elements/ia-otp-input/ia-otp-input.ts
+++ b/src/elements/ia-otp-input/ia-otp-input.ts
@@ -1,0 +1,216 @@
+import {
+  html,
+  LitElement,
+  TemplateResult,
+  CSSResultGroup,
+  css,
+  PropertyValues,
+} from 'lit';
+import { property, customElement, queryAll } from 'lit/decorators.js';
+
+const NUMERIC_REGEX = /^[0-9]+$/;
+const ALPHANUMERIC_REGEX = /^[a-zA-Z0-9]+$/;
+
+/**
+ * Renders an input for OTP entry, which combines a series of separate
+ * inputs into one, shifting focus as needed and handling paste and backspace
+ * events.
+ */
+@customElement('ia-otp-input')
+export class IAOTPInput extends LitElement {
+  /* An optional value to prefill the inputs with */
+  @property({ type: String })
+  prefillValue?: string;
+
+  /* Whether to disable all inputs */
+  @property({ type: Boolean })
+  disabled: boolean = false;
+
+  /* Number of characters to expect for the passcode */
+  @property({ type: Number })
+  numChars: number = 6;
+
+  /* Whether to restrict entry to numeric characters */
+  @property({ type: Boolean })
+  numericOnly: boolean = true;
+
+  /* Regex for allowed characters. Updates based on numeric only */
+  @property({ type: Object })
+  private allowedChars: RegExp = NUMERIC_REGEX;
+
+  /* Array of OTP inputs */
+  @queryAll('input')
+  private inputs!: NodeListOf<HTMLInputElement>;
+
+  render(): TemplateResult {
+    return html`
+      ${[...Array(this.numChars).keys()].map(
+        (i) =>
+          html`<input
+            id="OTP-input-${i}"
+            type="text"
+            autocomplete=${i === 0 ? 'one-time-code' : 'off'}
+            inputmode=${this.numericOnly ? 'numeric' : 'text'}
+            ?disabled=${this.disabled}
+            @beforeinput=${this.handleInput}
+            @paste=${this.handlePaste}
+            @keydown=${this.handleKeydown}
+          />`,
+      )}
+    `;
+  }
+
+  protected firstUpdated(): void {
+    this.inputs[0].focus();
+  }
+
+  protected willUpdate(changed: PropertyValues): void {
+    if (changed.has('numericOnly')) {
+      this.allowedChars = this.numericOnly ? NUMERIC_REGEX : ALPHANUMERIC_REGEX;
+    }
+
+    if (changed.has('prefillValue') && this.prefillValue !== undefined) {
+      this.fillInputs(this.prefillValue);
+      this.prefillValue = undefined;
+    }
+  }
+
+  /* Shifts forward on input */
+  private handleInput(e: InputEvent): void {
+    e.preventDefault();
+    const input = e.target as HTMLInputElement;
+    const addedValue = e.data;
+
+    if (!addedValue) return;
+    if (addedValue.length > 1) {
+      this.fillInputs(addedValue);
+      return;
+    }
+    if (!this.allowedChars.test(addedValue)) return;
+
+    input.value = addedValue;
+    const next = input.nextElementSibling as HTMLInputElement;
+    if (next) next.focus();
+
+    this.submitIfInputsFilled();
+  }
+
+  /* Performs special actions associated with some keys */
+  private handleKeydown(e: KeyboardEvent): void {
+    const input = e.target as HTMLInputElement;
+    const key = e.key.toLowerCase();
+    const prev = input.previousElementSibling as HTMLInputElement;
+    const next = input.nextElementSibling as HTMLInputElement;
+
+    switch (key) {
+      case 'backspace':
+      case 'delete':
+        e.preventDefault();
+        if (prev) prev.focus();
+
+        if (input.value === '') {
+          prev.value = '';
+          break;
+        }
+
+        input.value = '';
+        break;
+      case 'tab':
+        input.select();
+        break;
+      case 'arrowright':
+        e.preventDefault();
+        if (next) next.focus();
+        break;
+      case 'arrowleft':
+        e.preventDefault();
+        if (prev) prev.focus();
+        break;
+    }
+  }
+
+  /**
+   * Transmits pasted data to the input-filling function
+   */
+  private handlePaste(e: ClipboardEvent): void {
+    e.preventDefault();
+
+    const pastedText = e.clipboardData?.getData('text');
+    if (pastedText) this.fillInputs(pastedText);
+  }
+
+  /**
+   * Fills as many inputs as possible with the specified value, starting from the beginning.
+   * Submits the result if enough characters are filled.
+   */
+  private fillInputs(value: string) {
+    if (value === '') this.clearInputs();
+
+    const charsToFill = value
+      .split('')
+      .filter((char) => this.allowedChars.test(char))
+      .slice(0, this.numChars);
+
+    if (!charsToFill || charsToFill.length === 0) return;
+    charsToFill.forEach(
+      (char, i) => ((this.inputs[i] as HTMLInputElement).value = char),
+    );
+
+    if (charsToFill.length === this.numChars) {
+      this.triggerSubmit(charsToFill.join(''));
+      this.inputs[this.numChars - 1].focus();
+      return;
+    }
+
+    const next = this.inputs[charsToFill.length];
+    next.focus();
+  }
+
+  /** Clears all inputs and returns focus to first input */
+  private clearInputs(): void {
+    this.inputs.forEach((input) => (input.value = ''));
+    this.inputs[0].focus();
+  }
+
+  /** Checks whether all inputs are filled and submits if so */
+  private submitIfInputsFilled(): void {
+    const code: string[] = [];
+    this.inputs.forEach((input) => {
+      if (input.value) code.push(input.value);
+    });
+
+    if (code.length === this.numChars) this.triggerSubmit(code.join(''));
+  }
+
+  /* Submits code */
+  private triggerSubmit(code: string): void {
+    this.dispatchEvent(
+      new CustomEvent('codeSubmitted', {
+        detail: code,
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  static get styles(): CSSResultGroup {
+    return css`
+      :host {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: nowrap;
+        gap: 5px;
+      }
+
+      input {
+        font-size: 36px;
+        font-weight: bold;
+        width: 36px;
+        height: 56px;
+        text-align: center;
+        text-transform: uppercase;
+        padding: 0;
+      }
+    `;
+  }
+}

--- a/src/elements/ia-otp-input/ia-otp-input.ts
+++ b/src/elements/ia-otp-input/ia-otp-input.ts
@@ -107,13 +107,13 @@ export class IAOTPInput extends LitElement {
   /* Performs special actions associated with some keys */
   private handleKeydown(e: KeyboardEvent): void {
     const input = e.target as HTMLInputElement;
-    const key = e.key.toLowerCase();
+    const key = e.key;
     const prev = input.previousElementSibling as HTMLInputElement;
     const next = input.nextElementSibling as HTMLInputElement;
 
     switch (key) {
-      case 'backspace':
-      case 'delete':
+      case 'Backspace':
+      case 'Delete':
         e.preventDefault();
         if (prev) prev.focus();
 
@@ -124,14 +124,16 @@ export class IAOTPInput extends LitElement {
 
         input.value = '';
         break;
-      case 'tab':
+      case 'Tab':
         input.select();
         break;
-      case 'arrowright':
+      case 'ArrowRight':
+      case 'Right':
         e.preventDefault();
         if (next) next.focus();
         break;
-      case 'arrowleft':
+      case 'ArrowLeft':
+      case 'Left':
         e.preventDefault();
         if (prev) prev.focus();
         break;

--- a/src/themes/theme-styles.ts
+++ b/src/themes/theme-styles.ts
@@ -15,6 +15,7 @@ const themeStyles = css`
     --default-icon-width: 1.25rem;
     --default-padding-sm: 5px;
     --default-combo-box-width: auto;
+    --default-font-size-lg: 2.25rem;
 
     /* Colors */
     --true-white: #fff;
@@ -50,6 +51,7 @@ const themeStyles = css`
       --ia-theme-combo-box-width,
       var(--default-combo-box-width)
     );
+    --font-size-lg: var(--ia-theme-font-size-lg, var(--default-font-size-lg));
 
     /* Backgrounds and fills */
     --primary-background-color: var(


### PR DESCRIPTION
Builds out a simple OTP input component (just the boxes and pasting/arrow key behavior), migrated from an existing Offshoot component.

Also expands the prop settings to support boolean and number props.