### PR TITLE
WEBDEV-8393 Add full OTP form

### DIFF
--- a/demo/story-components/story-prop-settings.ts
+++ b/demo/story-components/story-prop-settings.ts
@@ -147,7 +147,7 @@ export class StoryPropsSettings extends LitElement {
     this.dispatchEvent(
       new CustomEvent('propsApplied', {
         detail: {
-          stringifiedProps: '\n  ' + stringifiedProps.join('\n  ') + '\n',
+          stringifiedProps: stringifiedProps.join('\n  '),
           appliedProps,
         },
       }),

--- a/demo/story-template.ts
+++ b/demo/story-template.ts
@@ -213,10 +213,14 @@ export class StoryTemplate extends LitElement {
 
   private get exampleUsage(): string {
     const defaultProps = this.defaultUsageProps
-      ? '\n ' + this.defaultUsageProps + '\n'
+      ? '  ' + this.defaultUsageProps + '\n'
       : '';
-    const appliedProps = this.stringifiedProps ?? '';
-    return `<${this.elementTag}${defaultProps}${appliedProps}></${this.elementTag}>`;
+    const appliedProps = this.stringifiedProps
+      ? '  ' + this.stringifiedProps + '\n'
+      : '';
+    const hasProps = !!defaultProps || !!appliedProps;
+
+    return `<${this.elementTag}${hasProps ? '\n' : ''}${defaultProps}${appliedProps}></${this.elementTag}>`;
   }
 
   private get cssCode(): string {

--- a/demo/story-template.ts
+++ b/demo/story-template.ts
@@ -48,6 +48,9 @@ export class StoryTemplate extends LitElement {
   /* Whether settings inputs have been slotted in and should be displayed */
   @state() private shouldShowPropertySettings: boolean = false;
 
+  /* Whether notes have been slotted in and should be displayed */
+  @state() private shouldShowUsageNotes: boolean = false;
+
   /* Component that has been slotted into the demo, if applicable */
   @state() private slottedDemoComponent?: any;
 
@@ -186,6 +189,13 @@ export class StoryTemplate extends LitElement {
           )}
         </div>
       </div>
+      ${when(this.shouldShowUsageNotes, () => html` <h3>Usage Notes</h3>`)}
+      <div class="slot-container">
+        <slot
+          name="usage-notes"
+          @slotchange=${this.handleUsageNotesSlotChange}
+        ></slot>
+      </div>
     `;
   }
 
@@ -238,6 +248,12 @@ export class StoryTemplate extends LitElement {
   private handleSettingsSlotChange(e: Event): void {
     const slottedChildren = (e.target as HTMLSlotElement).assignedElements();
     this.shouldShowPropertySettings = slottedChildren.length > 0;
+  }
+
+  /* Toggles visibility of section heading depending on whether notes have been slotted in */
+  private handleUsageNotesSlotChange(e: Event): void {
+    const slottedChildren = (e.target as HTMLSlotElement).assignedElements();
+    this.shouldShowUsageNotes = slottedChildren.length > 0;
   }
 
   /* Detects and stores a reference to slotted demo component */

--- a/src/elements/ia-otp-form/ia-otp-form-story.ts
+++ b/src/elements/ia-otp-form/ia-otp-form-story.ts
@@ -60,7 +60,7 @@ export class IAOTPFormStory extends LitElement {
       <story-template
         elementTag="ia-otp-form"
         elementClassName="IAOTPForm"
-        .defaultUsageProps=${"@codeSubmitted=\${(e: CustomEvent) => alert('Code submitted: ' + e.detail)} \n @newCodeRequested=\${() => alert('New code requested')}"}
+        .defaultUsageProps=${"@codeSubmitted=\${(e: CustomEvent) => alert('Code submitted: ' + e.detail)} \n  @newCodeRequested=\${() => alert('New code requested')}"}
         .styleInputData=${{ settings: styleInputSettings }}
         .propInputData=${{ settings: propInputSettings }}
       >

--- a/src/elements/ia-otp-form/ia-otp-form-story.ts
+++ b/src/elements/ia-otp-form/ia-otp-form-story.ts
@@ -16,10 +16,34 @@ const styleInputSettings: StyleInputSettings[] = [
     inputType: 'color',
   },
   {
-    label: 'Font size',
+    label: 'Input font size',
     cssVariable: '--ia-theme-font-size-lg',
     defaultValue: '2.25rem',
     inputType: 'text',
+  },
+  {
+    label: 'Link and error font size',
+    cssVariable: '--ia-theme-font-size-standard',
+    defaultValue: '0.875rem',
+    inputType: 'text',
+  },
+  {
+    label: 'Link font color',
+    cssVariable: '--ia-theme-link-color',
+    defaultValue: '#4b64ff',
+    inputType: 'color',
+  },
+  {
+    label: 'Error message/indicator color',
+    cssVariable: '--ia-theme-color-danger',
+    defaultValue: '#e51c23',
+    inputType: 'color',
+  },
+  {
+    label: 'Success indicator color',
+    cssVariable: '--ia-theme-color-success',
+    defaultValue: '#31a481',
+    inputType: 'color',
   },
 ];
 

--- a/src/elements/ia-otp-form/ia-otp-form-story.ts
+++ b/src/elements/ia-otp-form/ia-otp-form-story.ts
@@ -84,14 +84,15 @@ export class IAOTPFormStory extends LitElement {
       <story-template
         elementTag="ia-otp-form"
         elementClassName="IAOTPForm"
-        .defaultUsageProps=${"@codeSubmitted=\${(e: CustomEvent) => alert('Code submitted: ' + e.detail)} \n  @newCodeRequested=\${() => alert('New code requested')}"}
+        .defaultUsageProps=${"@codeSubmitted=\${(e: CustomEvent) => {setTimeout(() => alert('Code submitted: ' + e.detail), 250);}} \n  @newCodeRequested=\${() => alert('New code requested')}"}
         .styleInputData=${{ settings: styleInputSettings }}
         .propInputData=${{ settings: propInputSettings }}
       >
         <ia-otp-form
           slot="demo"
-          @codeSubmitted=${(e: CustomEvent) =>
-            alert('Code submitted: ' + e.detail)}
+          @codeSubmitted=${(e: CustomEvent) => {
+            setTimeout(() => alert('Code submitted: ' + e.detail), 250);
+          }}
           @newCodeRequested=${() => alert('New code requested')}
         ></ia-otp-form>
       </story-template>

--- a/src/elements/ia-otp-form/ia-otp-form-story.ts
+++ b/src/elements/ia-otp-form/ia-otp-form-story.ts
@@ -3,9 +3,9 @@ import { customElement } from 'lit/decorators.js';
 
 import type { PropInputSettings } from '@demo/story-components/story-prop-settings';
 import type { StyleInputSettings } from '@demo/story-components/story-styles-settings';
-import type { IAOTPInput } from './ia-otp-input';
+import type { IAOTPForm } from './ia-otp-form';
 
-import './ia-otp-input';
+import './ia-otp-form';
 import '@demo/story-template';
 
 const styleInputSettings: StyleInputSettings[] = [
@@ -23,12 +23,20 @@ const styleInputSettings: StyleInputSettings[] = [
   },
 ];
 
-const propInputSettings: PropInputSettings<IAOTPInput>[] = [
+const propInputSettings: PropInputSettings<IAOTPForm>[] = [
   {
-    label: 'Number of characters',
-    propertyName: 'numChars',
-    defaultValue: 6,
-    inputType: 'number',
+    label: 'Validation Status',
+    propertyName: 'validationStatus',
+    defaultValue: 'ready',
+    inputType: 'radio',
+    radioOptions: ['ready', 'loading', 'success', 'error'],
+  },
+  {
+    label: 'New code sending in progress',
+    propertyName: 'newCodeSending',
+    defaultValue: false,
+    inputType: 'radio',
+    radioOptions: [true, false],
   },
   {
     label: 'Numeric only',
@@ -38,35 +46,30 @@ const propInputSettings: PropInputSettings<IAOTPInput>[] = [
     radioOptions: [true, false],
   },
   {
-    label: 'Prefill value',
-    propertyName: 'prefillValue',
-    defaultValue: '',
-  },
-  {
-    label: 'Disabled',
-    propertyName: 'disabled',
-    defaultValue: false,
-    inputType: 'radio',
-    radioOptions: [true, false],
+    label: 'Number of passcode characters',
+    propertyName: 'numPasscodeChars',
+    defaultValue: 6,
+    inputType: 'number',
   },
 ];
 
-@customElement('ia-otp-input-story')
-export class IAOTPInputStory extends LitElement {
+@customElement('ia-otp-form-story')
+export class IAOTPFormStory extends LitElement {
   render() {
     return html`
       <story-template
-        elementTag="ia-otp-input"
-        elementClassName="IAOTPInput"
-        .defaultUsageProps=${"@codeSubmitted=\${(e: CustomEvent) => alert('Code submitted: ' + e.detail)}"}
+        elementTag="ia-otp-form"
+        elementClassName="IAOTPForm"
+        .defaultUsageProps=${"@codeSubmitted=\${(e: CustomEvent) => alert('Code submitted: ' + e.detail)} \n @newCodeRequested=\${() => alert('New code requested')}"}
         .styleInputData=${{ settings: styleInputSettings }}
         .propInputData=${{ settings: propInputSettings }}
       >
-        <ia-otp-input
+        <ia-otp-form
+          slot="demo"
           @codeSubmitted=${(e: CustomEvent) =>
             alert('Code submitted: ' + e.detail)}
-          slot="demo"
-        ></ia-otp-input>
+          @newCodeRequested=${() => alert('New code requested')}
+        ></ia-otp-form>
       </story-template>
     `;
   }

--- a/src/elements/ia-otp-form/ia-otp-form-story.ts
+++ b/src/elements/ia-otp-form/ia-otp-form-story.ts
@@ -95,6 +95,37 @@ export class IAOTPFormStory extends LitElement {
           }}
           @newCodeRequested=${() => alert('New code requested')}
         ></ia-otp-form>
+        <div slot="usage-notes">
+          For a typical One Time Passcode (OTP) use case, the component can be
+          used like so:
+          <ul>
+            <li>
+              The parent component sends the user a code, then displays the
+              <code>ia-otp-form</code> component for code entry
+            </li>
+            <li>
+              Once the user finishes entering a code, the component emits a
+              <code>codeSubmitted</code> event with the code stored in the event
+              <code>detail</code>
+            </li>
+            <li>
+              The parent component sends that code to be verified and sets the
+              <code>validationStatus</code> to <code>loading</code>
+            </li>
+            <li>
+              Depending on the result, the parent then sets the
+              <code>validationStatus</code> to <code>success</code> or
+              <code>error</code> to display a success or error state
+            </li>
+            <li>
+              If the user requests a new code from within the component, it will
+              emit a <code>newCodeRequested</code> event and clear the inputs,
+              and the parent can set the <code>newCodeSending</code> property to
+              <code>true</code> while the code is being sent, then back to
+              <code>false</code> when it is ready for entry
+            </li>
+          </ul>
+        </div>
       </story-template>
     `;
   }

--- a/src/elements/ia-otp-form/ia-otp-form.test.ts
+++ b/src/elements/ia-otp-form/ia-otp-form.test.ts
@@ -1,0 +1,164 @@
+import { fixture, oneEvent } from '@open-wc/testing-helpers';
+import { describe, expect, test } from 'vitest';
+import { html } from 'lit';
+
+import type { IAOTPInput } from '@src/elements/ia-otp-input/ia-otp-input';
+import type { IAStatusIndicator } from '@src/elements/ia-status-indicator/ia-status-indicator';
+import type { IAOTPForm } from './ia-otp-form';
+
+import './ia-otp-form';
+
+describe('IA OTP form', () => {
+  test('renders an OTP input by default', async () => {
+    const el = await fixture<IAOTPForm>(html`<ia-otp-form></ia-otp-form>`);
+
+    const OTPInput = el.shadowRoot?.querySelector('ia-otp-input');
+    expect(OTPInput).to.exist;
+  });
+
+  test('requests new code on "send me another code" button click', async () => {
+    const el = await fixture<IAOTPForm>(html`<ia-otp-form></ia-otp-form>`);
+
+    const eventPromise = oneEvent(el, 'newCodeRequested');
+
+    const newCodeBtn = el.shadowRoot?.querySelector(
+      '.new-code-btn',
+    ) as HTMLButtonElement;
+    newCodeBtn?.click();
+
+    const codeRequestEvent = await eventPromise;
+    expect(codeRequestEvent).to.exist;
+  });
+
+  test('clears current input on "send me another code" button click', async () => {
+    const el = await fixture<IAOTPForm>(html`<ia-otp-form></ia-otp-form>`);
+
+    const input = el.shadowRoot?.querySelector('ia-otp-input') as IAOTPInput;
+    input.prefillValue = '12345';
+
+    const newCodeBtn = el.shadowRoot?.querySelector(
+      '.new-code-btn',
+    ) as HTMLButtonElement;
+    newCodeBtn?.click();
+    expect(input.prefillValue).to.equal('');
+  });
+
+  test('can switch out button for loading message if new code sending', async () => {
+    const el = await fixture<IAOTPForm>(
+      html`<ia-otp-form .newCodeSending=${true}></ia-otp-form>`,
+    );
+
+    const newCodeBtn = el.shadowRoot?.querySelector(
+      '.new-code-btn',
+    ) as HTMLButtonElement;
+    const newCodeMsg = el.shadowRoot?.querySelector('.new-code-msg');
+    expect(newCodeBtn).not.to.exist;
+    expect(newCodeMsg).to.exist;
+  });
+
+  test('does not include email by default in "send me another code" request', async () => {
+    const el = await fixture<IAOTPForm>(html`<ia-otp-form></ia-otp-form>`);
+
+    const eventPromise = oneEvent(el, 'newCodeRequested');
+
+    const newCodeBtn = el.shadowRoot?.querySelector(
+      '.new-code-btn',
+    ) as HTMLButtonElement;
+    newCodeBtn?.click();
+
+    const codeRequestEvent = await eventPromise;
+    expect(codeRequestEvent).to.exist;
+    expect(codeRequestEvent.detail).to.be.null;
+  });
+
+  test('disables OTP input if validation in progress', async () => {
+    const el = await fixture<IAOTPForm>(
+      html`<ia-otp-form .validationStatus=${'loading'}></ia-otp-form>`,
+    );
+
+    const input = el.shadowRoot?.querySelector('ia-otp-input') as IAOTPInput;
+    expect(input.disabled).to.be.true;
+  });
+
+  test('disables new code button if validation in progress', async () => {
+    const el = await fixture<IAOTPForm>(
+      html`<ia-otp-form .validationStatus=${'loading'}></ia-otp-form>`,
+    );
+
+    const newCodeBtn = el.shadowRoot?.querySelector(
+      '.new-code-btn',
+    ) as HTMLButtonElement;
+    expect(newCodeBtn.disabled).to.be.true;
+  });
+
+  test('displays a loading indicator next to the input if validation in progress', async () => {
+    const el = await fixture<IAOTPForm>(
+      html`<ia-otp-form .validationStatus=${'loading'}></ia-otp-form>`,
+    );
+
+    const statusIndicator = el.shadowRoot?.querySelector(
+      'ia-status-indicator',
+    ) as IAStatusIndicator;
+    expect(statusIndicator.mode).to.equal('loading');
+  });
+
+  test('disables OTP input if validation successful', async () => {
+    const el = await fixture<IAOTPForm>(
+      html`<ia-otp-form .validationStatus=${'success'}></ia-otp-form>`,
+    );
+
+    const input = el.shadowRoot?.querySelector('ia-otp-input') as IAOTPInput;
+    expect(input.disabled).to.be.true;
+  });
+
+  test('displays a success icon next to the input if validation successful', async () => {
+    const el = await fixture<IAOTPForm>(
+      html`<ia-otp-form .validationStatus=${'success'}></ia-otp-form>`,
+    );
+
+    const statusIndicator = el.shadowRoot?.querySelector(
+      'ia-status-indicator',
+    ) as IAStatusIndicator;
+    expect(statusIndicator.mode).to.equal('success');
+  });
+
+  test('does not disable OTP input if validation not successful', async () => {
+    const el = await fixture<IAOTPForm>(
+      html`<ia-otp-form .validationStatus=${'error'}></ia-otp-form>`,
+    );
+
+    const input = el.shadowRoot?.querySelector('ia-otp-input') as IAOTPInput;
+    expect(input.disabled).to.be.false;
+  });
+
+  test('clears OTP input if validation not successful', async () => {
+    const el = await fixture<IAOTPForm>(html`<ia-otp-form></ia-otp-form>`);
+    const input = el.shadowRoot?.querySelector('ia-otp-input') as IAOTPInput;
+    input.prefillValue = '12345';
+    el.validationStatus = 'error';
+
+    await el.updateComplete;
+
+    expect(input.prefillValue).to.equal(undefined);
+  });
+
+  test('displays an error icon next to the input if validation not successful', async () => {
+    const el = await fixture<IAOTPForm>(
+      html`<ia-otp-form .validationStatus=${'error'}></ia-otp-form>`,
+    );
+
+    const statusIndicator = el.shadowRoot?.querySelector(
+      'ia-status-indicator',
+    ) as IAStatusIndicator;
+    expect(statusIndicator.mode).to.equal('error');
+  });
+
+  test('displays an error message after the input if validation not successful', async () => {
+    const el = await fixture<IAOTPForm>(
+      html`<ia-otp-form .validationStatus=${'error'}></ia-otp-form>`,
+    );
+
+    const errorMessage = el.shadowRoot?.querySelector('.error-msg');
+    expect(errorMessage).to.exist;
+  });
+});

--- a/src/elements/ia-otp-form/ia-otp-form.ts
+++ b/src/elements/ia-otp-form/ia-otp-form.ts
@@ -1,0 +1,173 @@
+import {
+  html,
+  LitElement,
+  TemplateResult,
+  CSSResultGroup,
+  css,
+  nothing,
+  PropertyValues,
+} from 'lit';
+import { msg } from '@lit/localize';
+import { property, customElement, query } from 'lit/decorators.js';
+
+import type { IAOTPInput } from '@src/elements/ia-otp-input/ia-otp-input';
+import type { LoadingStatus } from '@src/elements/ia-status-indicator/ia-status-indicator';
+
+import '@src/elements/ia-status-indicator/ia-status-indicator';
+import '@src/elements/ia-otp-input/ia-otp-input';
+
+/**
+ * Custom events fired by the component
+ */
+const Events = {
+  NewCodeRequested: 'newCodeRequested',
+};
+
+/**
+ * Form for entering OTP codes, including success/loading/error states and a request new code button
+ */
+@customElement('ia-otp-form')
+export class IAOTPForm extends LitElement {
+  /* The email the OTP will be sent to */
+  @property({ type: String })
+  email?: string;
+
+  /* The state of the validation process */
+  @property({ type: String })
+  validationStatus: LoadingStatus = 'ready';
+
+  /* Whether to display a loading indicator instead of the button text */
+  @property({ type: Boolean })
+  newCodeSending: boolean = false;
+
+  /* Number of characters to expect for the passcode */
+  @property({ type: Number })
+  numPasscodeChars: number = 6;
+
+  /* Whether to restrict entry to numeric characters */
+  @property({ type: Boolean })
+  numericOnly: boolean = true;
+
+  @query('ia-otp-input')
+  private OTPInput!: IAOTPInput;
+
+  render(): TemplateResult {
+    return html`
+      <div class="input-section">
+        <ia-otp-input
+          .numChars=${this.numPasscodeChars}
+          ?numericOnly=${this.numericOnly}
+          ?disabled=${this.validationStatus === 'loading' ||
+          this.validationStatus === 'success'}
+        ></ia-otp-input
+        >${this.iconTemplate}
+      </div>
+      ${this.validationStatus === 'error'
+        ? html`<p class="error-msg">
+            ${msg('The code entered is invalid or expired')}
+          </p>`
+        : nothing}
+      ${this.resendCodeButtonTemplate}
+    `;
+  }
+
+  protected willUpdate(changed: PropertyValues): void {
+    if (
+      changed.has('validationStatus') &&
+      this.OTPInput &&
+      this.validationStatus === 'error'
+    ) {
+      this.OTPInput.prefillValue = '';
+    }
+  }
+
+  /* The icon to display next to the input, if necessary */
+  private get iconTemplate(): TemplateResult {
+    return html`
+      <div class="icon">
+        <ia-status-indicator
+          class="status-indicator"
+          .mode=${this.validationStatus}
+        ></ia-status-indicator>
+      </div>
+    `;
+  }
+
+  /* The button to display to send a new code */
+  private get resendCodeButtonTemplate(): TemplateResult {
+    return this.newCodeSending
+      ? html`<span class="new-code-msg">${msg('Emailing...')}</span>`
+      : html`
+          <button
+            class="new-code-btn link"
+            .disabled=${this.validationStatus === 'loading' ||
+            this.validationStatus === 'success'}
+            @click=${this.handleNewCodeRequested}
+          >
+            ${msg('Email me another code')}
+          </button>
+        `;
+  }
+
+  /* Emits an event to request the new code */
+  private async handleNewCodeRequested(): Promise<void> {
+    this.dispatchEvent(
+      new CustomEvent(Events.NewCodeRequested, {
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    this.OTPInput.prefillValue = '';
+  }
+
+  static get styles(): CSSResultGroup {
+    return css`
+      :host {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .input-section {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 5px;
+      }
+
+      .icon {
+        display: block;
+        width: 48px;
+        height: 48px;
+      }
+
+      .status-indicator {
+        --icon-width: 48px;
+      }
+
+      .error-msg {
+        margin-top: 10px;
+        font-size: 1.4rem;
+        color: var(--ia-theme-error, #e51c23);
+        margin-bottom: -10px;
+      }
+
+      .new-code-btn {
+        display: block;
+        width: fit-content;
+        margin-top: 10px;
+      }
+
+      .new-code-msg {
+        margin-top: 10px;
+        font-size: 1.4rem;
+        color: var(--ia-theme-link-color, #4b64ff);
+        min-height: 3.5rem;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+      }
+    `;
+  }
+}

--- a/src/elements/ia-otp-form/ia-otp-form.ts
+++ b/src/elements/ia-otp-form/ia-otp-form.ts
@@ -58,8 +58,12 @@ export class IAOTPForm extends LitElement {
           ?numericOnly=${this.numericOnly}
           ?disabled=${this.validationStatus === 'loading' ||
           this.validationStatus === 'success'}
-        ></ia-otp-input
-        >${this.iconTemplate}
+        ></ia-otp-input>
+        <ia-status-indicator
+          class="status-indicator"
+          part="status-indicator"
+          .mode=${this.validationStatus}
+        ></ia-status-indicator>
       </div>
       ${this.validationStatus === 'error'
         ? html`<p class="error-msg">
@@ -80,25 +84,16 @@ export class IAOTPForm extends LitElement {
     }
   }
 
-  /* The icon to display next to the input, if necessary */
-  private get iconTemplate(): TemplateResult {
-    return html`
-      <div class="icon">
-        <ia-status-indicator
-          class="status-indicator"
-          .mode=${this.validationStatus}
-        ></ia-status-indicator>
-      </div>
-    `;
-  }
-
   /* The button to display to send a new code */
   private get resendCodeButtonTemplate(): TemplateResult {
     return this.newCodeSending
-      ? html`<span class="new-code-msg">${msg('Emailing...')}</span>`
+      ? html`<span part="new-code-message" class="new-code-msg"
+          >${msg('Emailing...')}</span
+        >`
       : html`
           <button
             class="new-code-btn link"
+            part="new-code-button"
             .disabled=${this.validationStatus === 'loading' ||
             this.validationStatus === 'success'}
             @click=${this.handleNewCodeRequested}
@@ -124,6 +119,12 @@ export class IAOTPForm extends LitElement {
       themeStyles,
       css`
         :host {
+          --font-size-standard--: var(--font-size-standard);
+          --font-size-lg--: var(--font-size-lg);
+          --color-success--: var(--color-success);
+          --color-danger--: var(--color-danger);
+          --link-color--: var(--link-color);
+
           display: flex;
           flex-direction: column;
           align-items: center;
@@ -134,37 +135,45 @@ export class IAOTPForm extends LitElement {
           display: flex;
           flex-direction: row;
           align-items: center;
+          justify-content: center;
           gap: 5px;
         }
 
-        .icon {
-          display: block;
-          width: 48px;
-          height: 48px;
-        }
-
         .status-indicator {
-          --icon-width: 48px;
+          --icon-width: calc(var(--font-size-lg--) * 1.33);
         }
 
         .error-msg {
           margin-top: 10px;
-          font-size: 1.4rem;
-          color: var(--ia-theme-error, #e51c23);
+          font-size: var(--font-size-standard--);
+          color: var(--color-danger--);
           margin-bottom: -10px;
         }
 
         .new-code-btn {
+          font-family: inherit;
+          font-size: var(--font-size-standard--);
           display: block;
           width: fit-content;
           margin-top: 10px;
+          border: 0;
+          padding: 0;
+          appearance: none;
+          background: none;
+          color: var(--link-color--);
+          text-decoration: none;
+          cursor: pointer;
+        }
+
+        .new-code-btn:hover,
+        .new-code-btn:focus {
+          text-decoration: underline;
         }
 
         .new-code-msg {
           margin-top: 10px;
-          font-size: 1.4rem;
-          color: var(--ia-theme-link-color, #4b64ff);
-          min-height: 3.5rem;
+          font-size: var(--font-size-standard--);
+          color: var(--link-color--);
           display: flex;
           flex-direction: column;
           justify-content: center;

--- a/src/elements/ia-otp-form/ia-otp-form.ts
+++ b/src/elements/ia-otp-form/ia-otp-form.ts
@@ -82,6 +82,10 @@ export class IAOTPForm extends LitElement {
     ) {
       this.OTPInput.prefillValue = '';
     }
+
+    if (changed.has('newCodeSending') && this.newCodeSending && this.OTPInput) {
+      this.OTPInput.prefillValue = '';
+    }
   }
 
   /* The button to display to send a new code */

--- a/src/elements/ia-otp-form/ia-otp-form.ts
+++ b/src/elements/ia-otp-form/ia-otp-form.ts
@@ -10,6 +10,8 @@ import {
 import { msg } from '@lit/localize';
 import { property, customElement, query } from 'lit/decorators.js';
 
+import themeStyles from '@src/themes/theme-styles';
+
 import type { IAOTPInput } from '@src/elements/ia-otp-input/ia-otp-input';
 import type { LoadingStatus } from '@src/elements/ia-status-indicator/ia-status-indicator';
 
@@ -21,6 +23,7 @@ import '@src/elements/ia-otp-input/ia-otp-input';
  */
 const Events = {
   NewCodeRequested: 'newCodeRequested',
+  CodeSubmitted: 'codeSubmitted', // Bubbles up from ia-otp-input
 };
 
 /**
@@ -28,10 +31,6 @@ const Events = {
  */
 @customElement('ia-otp-form')
 export class IAOTPForm extends LitElement {
-  /* The email the OTP will be sent to */
-  @property({ type: String })
-  email?: string;
-
   /* The state of the validation process */
   @property({ type: String })
   validationStatus: LoadingStatus = 'ready';
@@ -121,53 +120,56 @@ export class IAOTPForm extends LitElement {
   }
 
   static get styles(): CSSResultGroup {
-    return css`
-      :host {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-      }
+    return [
+      themeStyles,
+      css`
+        :host {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+        }
 
-      .input-section {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        gap: 5px;
-      }
+        .input-section {
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+          gap: 5px;
+        }
 
-      .icon {
-        display: block;
-        width: 48px;
-        height: 48px;
-      }
+        .icon {
+          display: block;
+          width: 48px;
+          height: 48px;
+        }
 
-      .status-indicator {
-        --icon-width: 48px;
-      }
+        .status-indicator {
+          --icon-width: 48px;
+        }
 
-      .error-msg {
-        margin-top: 10px;
-        font-size: 1.4rem;
-        color: var(--ia-theme-error, #e51c23);
-        margin-bottom: -10px;
-      }
+        .error-msg {
+          margin-top: 10px;
+          font-size: 1.4rem;
+          color: var(--ia-theme-error, #e51c23);
+          margin-bottom: -10px;
+        }
 
-      .new-code-btn {
-        display: block;
-        width: fit-content;
-        margin-top: 10px;
-      }
+        .new-code-btn {
+          display: block;
+          width: fit-content;
+          margin-top: 10px;
+        }
 
-      .new-code-msg {
-        margin-top: 10px;
-        font-size: 1.4rem;
-        color: var(--ia-theme-link-color, #4b64ff);
-        min-height: 3.5rem;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-      }
-    `;
+        .new-code-msg {
+          margin-top: 10px;
+          font-size: 1.4rem;
+          color: var(--ia-theme-link-color, #4b64ff);
+          min-height: 3.5rem;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+        }
+      `,
+    ];
   }
 }

--- a/src/elements/ia-otp-form/ia-otp-form.ts
+++ b/src/elements/ia-otp-form/ia-otp-form.ts
@@ -60,7 +60,6 @@ export class IAOTPForm extends LitElement {
           this.validationStatus === 'success'}
         ></ia-otp-input>
         <ia-status-indicator
-          class="status-indicator"
           part="status-indicator"
           .mode=${this.validationStatus}
         ></ia-status-indicator>
@@ -143,7 +142,7 @@ export class IAOTPForm extends LitElement {
           gap: 5px;
         }
 
-        .status-indicator {
+        ia-status-indicator {
           --icon-width: calc(var(--font-size-lg--) * 1.33);
         }
 

--- a/src/elements/ia-otp-input/ia-otp-input-story.ts
+++ b/src/elements/ia-otp-input/ia-otp-input-story.ts
@@ -58,13 +58,14 @@ export class IAOTPInputStory extends LitElement {
       <story-template
         elementTag="ia-otp-input"
         elementClassName="IAOTPInput"
-        .defaultUsageProps=${"@codeSubmitted=\${(e: CustomEvent) => alert('Code submitted: ' + e.detail)}"}
+        .defaultUsageProps=${"@codeSubmitted=\${(e: CustomEvent) => {setTimeout(() => alert('Code submitted: ' + e.detail), 250);}}"}
         .styleInputData=${{ settings: styleInputSettings }}
         .propInputData=${{ settings: propInputSettings }}
       >
         <ia-otp-input
-          @codeSubmitted=${(e: CustomEvent) =>
-            alert('Code submitted: ' + e.detail)}
+          @codeSubmitted=${(e: CustomEvent) => {
+            setTimeout(() => alert('Code submitted: ' + e.detail), 250);
+          }}
           slot="demo"
         ></ia-otp-input>
       </story-template>

--- a/src/elements/ia-status-indicator/ia-status-indicator-story.ts
+++ b/src/elements/ia-status-indicator/ia-status-indicator-story.ts
@@ -40,7 +40,7 @@ const propInputSettings: PropInputSettings<IAStatusIndicator>[] = [
     propertyName: 'mode',
     defaultValue: 'loading',
     inputType: 'radio',
-    radioOptions: ['loading', 'success', 'error'],
+    radioOptions: ['ready', 'loading', 'success', 'error'],
   },
   {
     label: 'Accessible title - loading',

--- a/src/elements/ia-status-indicator/ia-status-indicator.test.ts
+++ b/src/elements/ia-status-indicator/ia-status-indicator.test.ts
@@ -112,4 +112,12 @@ describe('IA Status Indicator', () => {
     const indicatorTitle = el.shadowRoot?.querySelector('title');
     expect(indicatorTitle?.innerHTML).to.contain('Error');
   });
+
+  test('can render a placeholder instead if requested', async () => {
+    const el = await fixture<IAStatusIndicator>(
+      html`<ia-status-indicator .mode=${'ready'}></ia-status-indicator>`,
+    );
+    const placeholder = el.shadowRoot?.querySelector('.placeholder');
+    expect(placeholder).to.exist;
+  });
 });

--- a/src/elements/ia-status-indicator/ia-status-indicator.ts
+++ b/src/elements/ia-status-indicator/ia-status-indicator.ts
@@ -5,6 +5,8 @@ import { choose } from 'lit/directives/choose.js';
 
 import themeStyles from '@src/themes/theme-styles';
 
+export type LoadingStatus = 'ready' | 'loading' | 'success' | 'error';
+
 /**
  * Renders an SVG indicator, which defualts to an animated circular indicator
  */
@@ -23,14 +25,20 @@ export class IAStatusIndicator extends LitElement {
   @property({ type: String }) loadingStyle: 'ring' | 'ring-dots' = 'ring-dots';
 
   /* The state of the indicator that should be shown */
-  @property({ type: String }) mode: 'loading' | 'success' | 'error' = 'loading';
+  @property({ type: String }) mode: LoadingStatus = 'loading';
 
   render(): TemplateResult {
     return html`${choose(this.mode, [
+      ['ready', () => this.placeholderTemplate],
       ['loading', () => this.loadingIndicatorTemplate],
       ['success', () => this.successIndicatorTemplate],
       ['error', () => this.errorIndicatorTemplate],
     ])}`;
+  }
+
+  /** A placeholder to render before loading begins, if desired */
+  private get placeholderTemplate(): TemplateResult {
+    return html`<div class="placeholder"></div>`;
   }
 
   /** A circular loading indicator to render when processing */
@@ -139,6 +147,10 @@ export class IAStatusIndicator extends LitElement {
 
           display: inline-block;
           width: var(--indicator-width--);
+        }
+
+        .placeholder {
+          height: var(--indicator-width--);
         }
 
         .success-icon {

--- a/src/themes/theme-styles.ts
+++ b/src/themes/theme-styles.ts
@@ -15,7 +15,8 @@ const themeStyles = css`
     --default-icon-width: 1.25rem;
     --default-padding-sm: 5px;
     --default-combo-box-width: auto;
-    --default-font-size-lg: 2.25rem;
+    --default-font-size-standard: 0.875rem; /* 14px with 16px root font size */
+    --default-font-size-lg: 2.25rem; /* 36px with 16px root font size */
 
     /* Colors */
     --true-white: #fff;
@@ -50,6 +51,10 @@ const themeStyles = css`
     --combo-box-width: var(
       --ia-theme-combo-box-width,
       var(--default-combo-box-width)
+    );
+    --font-size-standard: var(
+      --ia-theme-font-size-standard,
+      var(--default-font-size-standard)
     );
     --font-size-lg: var(--ia-theme-font-size-lg, var(--default-font-size-lg));
 


### PR DESCRIPTION
Adds the full OTP form which builds on the OTP input component with loading/success/error states and a new code button.

Also adds an optional `Usage notes` section to the story template so that additional information/mini docs can be provided for components that need it.