### PR TITLE
v0.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/elements",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/elements",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@lit/localize": "^0.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/elements",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A web component library from the Internet Archive.",
   "license": "AGPL-3.0-only",
   "types": "./dist/src/elements/index.d.ts",


### PR DESCRIPTION
Bumps version to `v0.2.3` which releases two OTP components.