### PR TITLE
v0.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/elements",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/elements",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/ia-clearable-text-input": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/elements",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "description": "A web component library from the Internet Archive.",
   "license": "AGPL-3.0-only",
   "types": "./dist/src/elements/index.d.ts",


### PR DESCRIPTION
Version bump to `0.2.5`, including the new `<ia-dropdown-search-bar>` component.