### PR TITLE
WEBDEV-8447 Upgrade ia-dropdown version to address z-index bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/ia-clearable-text-input": "^1.1.1",
-        "@internetarchive/ia-dropdown": "2.2.0-alpha-webdev8447.0",
+        "@internetarchive/ia-dropdown": "^2.2.0",
         "@lit/localize": "^0.12.2",
         "lit": "^2.8.0 || ^3.3.2",
         "magic-snowflakes": "^7.0.2",
@@ -815,9 +815,9 @@
       }
     },
     "node_modules/@internetarchive/ia-dropdown": {
-      "version": "2.2.0-alpha-webdev8447.0",
-      "resolved": "https://registry.npmjs.org/@internetarchive/ia-dropdown/-/ia-dropdown-2.2.0-alpha-webdev8447.0.tgz",
-      "integrity": "sha512-55GKBRmNxHsnDEfAPMe4gikakG+F3XR17O2FXf2NiKeWyhGTe0U+oKsWD7rb4s8fQB5DwBEiZ4cg3LxmaLHk7w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@internetarchive/ia-dropdown/-/ia-dropdown-2.2.0.tgz",
+      "integrity": "sha512-h1vF1qLmjbPcRVkYz3kv1HzNHhucaM+IorVzvUejgYhIYRxrBjCswpOpMXeoR16UE4pyDVc/mtkKq/QFaVinRw==",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "lit": "^2.8.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/elements",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/elements",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/ia-clearable-text-input": "^1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/ia-clearable-text-input": "^1.1.1",
-        "@internetarchive/ia-dropdown": "^2.1.0",
+        "@internetarchive/ia-dropdown": "2.2.0-alpha-webdev8447.0",
         "@lit/localize": "^0.12.2",
         "lit": "^2.8.0 || ^3.3.2",
         "magic-snowflakes": "^7.0.2",
@@ -815,9 +815,9 @@
       }
     },
     "node_modules/@internetarchive/ia-dropdown": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@internetarchive/ia-dropdown/-/ia-dropdown-2.1.0.tgz",
-      "integrity": "sha512-FL8g78+42SiXEP21z6TjFHYGNtnG/sI6NUlPfft9GTlzOhz4QA9THRooSqa6fXeuatMPwqH4fTGhz6inwvKQ6Q==",
+      "version": "2.2.0-alpha-webdev8447.0",
+      "resolved": "https://registry.npmjs.org/@internetarchive/ia-dropdown/-/ia-dropdown-2.2.0-alpha-webdev8447.0.tgz",
+      "integrity": "sha512-55GKBRmNxHsnDEfAPMe4gikakG+F3XR17O2FXf2NiKeWyhGTe0U+oKsWD7rb4s8fQB5DwBEiZ4cg3LxmaLHk7w==",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "lit": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@lit/localize": "^0.12.2",
     "@internetarchive/ia-clearable-text-input": "^1.1.1",
-    "@internetarchive/ia-dropdown": "^2.1.0",
+    "@internetarchive/ia-dropdown": "2.2.0-alpha-webdev8447.0",
     "lit": "^2.8.0 || ^3.3.2",
     "magic-snowflakes": "^7.0.2",
     "tslib": "^2.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/elements",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "A web component library from the Internet Archive.",
   "license": "AGPL-3.0-only",
   "types": "./dist/src/elements/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@lit/localize": "^0.12.2",
     "@internetarchive/ia-clearable-text-input": "^1.1.1",
-    "@internetarchive/ia-dropdown": "2.2.0-alpha-webdev8447.0",
+    "@internetarchive/ia-dropdown": "^2.2.0",
     "lit": "^2.8.0 || ^3.3.2",
     "magic-snowflakes": "^7.0.2",
     "tslib": "^2.8.1"


### PR DESCRIPTION
There is currently a bug with incorrect z-index behavior on the `ia-dropdown`. This upgrades to a newer version of that component that fixes the bug, to avoid component registry conflicts when the `ia-dropdown-search-bar` is used alongside other components that rely on the patched version of `ia-dropdown`.