### PR TITLE
WEBDEV-8464 Make ia-dropdown-search-bar propagate selection changes immediately

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@internetarchive/elements",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@internetarchive/elements",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@internetarchive/ia-clearable-text-input": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/elements",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "A web component library from the Internet Archive.",
   "license": "AGPL-3.0-only",
   "types": "./dist/src/elements/index.d.ts",

--- a/src/elements/ia-dropdown-search-bar/ia-dropdown-search-bar.ts
+++ b/src/elements/ia-dropdown-search-bar/ia-dropdown-search-bar.ts
@@ -77,7 +77,7 @@ export class IADropdownSearchBar extends LitElement {
   }
   
   willUpdate(changed: PropertyValues) {
-    // Push the new categories down to the inner dropdown immediately, since ia-dropdown
+    // Push new categories down to the inner dropdown immediately, since ia-dropdown
     // mutates its own selected option on interaction which can cause Lit's
     // property-binding diff to miss the change in certain cases.
     if (changed.has('selectedCategory') || changed.has('categories')) {

--- a/src/elements/ia-dropdown-search-bar/ia-dropdown-search-bar.ts
+++ b/src/elements/ia-dropdown-search-bar/ia-dropdown-search-bar.ts
@@ -1,6 +1,6 @@
 import { msg } from '@lit/localize';
 import { css, html, LitElement, nothing, TemplateResult } from 'lit';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property, state, query } from 'lit/decorators.js';
 import type { IaClearableTextInput } from '@internetarchive/ia-clearable-text-input';
 import type { optionInterface } from '@internetarchive/ia-dropdown';
 import type { SearchCategory, SearchRequestedDetail } from './models';
@@ -47,6 +47,7 @@ export class IADropdownSearchBar extends LitElement {
   private searchInput!: IaClearableTextInput;
 
   /** The effective selected category, falling back to the first in the list. */
+  @state()
   private get resolvedCategory(): string {
     return this.selectedCategory ?? this.categories?.[0]?.id ?? '';
   }

--- a/src/elements/ia-dropdown-search-bar/ia-dropdown-search-bar.ts
+++ b/src/elements/ia-dropdown-search-bar/ia-dropdown-search-bar.ts
@@ -1,8 +1,15 @@
 import { msg } from '@lit/localize';
-import { css, html, LitElement, nothing, TemplateResult } from 'lit';
-import { customElement, property, state, query } from 'lit/decorators.js';
+import {
+  css,
+  html,
+  LitElement,
+  nothing,
+  PropertyValues,
+  TemplateResult,
+} from 'lit';
+import { customElement, property, query } from 'lit/decorators.js';
 import type { IaClearableTextInput } from '@internetarchive/ia-clearable-text-input';
-import type { optionInterface } from '@internetarchive/ia-dropdown';
+import type { IaDropdown, optionInterface } from '@internetarchive/ia-dropdown';
 import type { SearchCategory, SearchRequestedDetail } from './models';
 
 import themeStyles from '@src/themes/theme-styles';
@@ -46,8 +53,10 @@ export class IADropdownSearchBar extends LitElement {
   @query('#search-input')
   private searchInput!: IaClearableTextInput;
 
+  @query('#category-dropdown')
+  private categoryDropdown?: IaDropdown;
+
   /** The effective selected category, falling back to the first in the list. */
-  @state()
   private get resolvedCategory(): string {
     return this.selectedCategory ?? this.categories?.[0]?.id ?? '';
   }
@@ -65,6 +74,21 @@ export class IADropdownSearchBar extends LitElement {
         </div>
       </div>
     `;
+  }
+  
+  willUpdate(changed: PropertyValues) {
+    // Push the new categories down to the inner dropdown immediately, since ia-dropdown
+    // mutates its own selected option on interaction which can cause Lit's
+    // property-binding diff to miss the change in certain cases.
+    if (changed.has('selectedCategory') || changed.has('categories')) {
+      const resolved = this.resolvedCategory;
+      if (
+        this.categoryDropdown &&
+        this.categoryDropdown.selectedOption !== resolved
+      ) {
+        this.categoryDropdown.selectedOption = resolved;
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Currently for `<ia-dropdown-search-bar>`, if one resets the `selectedCategory` property directly after a dropdown option is selected, the change does not propagate down to the inner ia-dropdown component via Lit's usual update cycle due to the property-binding diff seeing no change. This PR just propagates the new value immediately via `willUpdate` to ensure the same change is seen by every component in the tree.