### PR TITLE
WEBDEV-8504 Add ia-sr-only-text to Elements

### DIFF
--- a/demo/story-template.ts
+++ b/demo/story-template.ts
@@ -31,6 +31,9 @@ export class StoryTemplate extends LitElement {
   /* Optional stringified properties to always include in the example usage */
   @property({ type: String }) defaultUsageProps?: string;
 
+  /* Optional slotted content to always include in the example usage */
+  @property({ type: String }) defaultSlottedContent?: string;
+
   @property({ type: Object }) styleInputData?: StyleInputData;
 
   @property({ type: Object }) propInputData?: PropInputData;
@@ -229,8 +232,12 @@ export class StoryTemplate extends LitElement {
       ? '  ' + this.stringifiedProps + '\n'
       : '';
     const hasProps = !!defaultProps || !!appliedProps;
+    const slottedContent =
+      this.defaultSlottedContent && hasProps
+        ? '\n ' + this.defaultSlottedContent + '\n'
+        : this.defaultSlottedContent;
 
-    return `<${this.elementTag}${hasProps ? '\n' : ''}${defaultProps}${appliedProps}></${this.elementTag}>`;
+    return `<${this.elementTag}${hasProps ? '\n' : ''}${defaultProps}${appliedProps}>${slottedContent ?? ''}</${this.elementTag}>`;
   }
 
   private get cssCode(): string {

--- a/src/elements/ia-button/ia-button-story.ts
+++ b/src/elements/ia-button/ia-button-story.ts
@@ -253,6 +253,7 @@ export class IAButtonStory extends LitElement {
         elementTag="ia-button"
         elementClassName="IAButton"
         .defaultUsageProps=${`@click=\${() => alert('Button clicked!')}`}
+        .defaultSlottedContent=${'Click Me'}
         .styleInputData=${{ settings: styleInputSettings }}
         .propInputData=${{ settings: propInputSettings }}
       >

--- a/src/elements/ia-sr-only-text/ia-sr-only-text-story.ts
+++ b/src/elements/ia-sr-only-text/ia-sr-only-text-story.ts
@@ -24,6 +24,16 @@ export class IAStatusIndicatorStory extends LitElement {
             Make text ${this.textVisible ? 'sr-only' : 'visible'}
           </button>
         </div>
+        <div slot="usage-notes">
+          <p>
+            Used to make text available for screen readers but not visible on
+            the page.
+          </p>
+          <p>
+            To see the hidden text in this demo, you can use the Chrome
+            accessibility tree or your browser's equivalent.
+          </p>
+        </div>
       </story-template>
     `;
   }

--- a/src/elements/ia-sr-only-text/ia-sr-only-text-story.ts
+++ b/src/elements/ia-sr-only-text/ia-sr-only-text-story.ts
@@ -1,0 +1,30 @@
+import { html, LitElement } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+
+import './ia-sr-only-text';
+import '@demo/story-template';
+
+@customElement('ia-sr-only-text-story')
+export class IAStatusIndicatorStory extends LitElement {
+  /* Whether to use the sr-only-text element */
+  @state() textVisible: boolean = false;
+
+  render() {
+    return html`
+      <story-template
+        elementTag="ia-sr-only-text"
+        elementClassName="IASrOnlyText"
+        defaultSlottedContent="Sample text"
+      >
+        <div slot="demo">
+          ${!this.textVisible
+            ? html`<ia-sr-only-text>Sample Text</ia-sr-only-text>`
+            : 'Sample Text'}
+          <button @click=${() => (this.textVisible = !this.textVisible)}>
+            Make text ${this.textVisible ? 'sr-only' : 'visible'}
+          </button>
+        </div>
+      </story-template>
+    `;
+  }
+}

--- a/src/elements/ia-sr-only-text/ia-sr-only-text.test.ts
+++ b/src/elements/ia-sr-only-text/ia-sr-only-text.test.ts
@@ -1,0 +1,28 @@
+import { fixture } from '@open-wc/testing-helpers';
+import { describe, expect, test } from 'vitest';
+import { html } from 'lit';
+
+import type { IASrOnlyText } from './ia-sr-only-text';
+import './ia-sr-only-text';
+
+describe('IA SR-only text', () => {
+  test('renders a span with the sr-only class by default', async () => {
+    const el = await fixture<IASrOnlyText>(
+      html`<ia-sr-only-text></ia-sr-only-text>`,
+    );
+    const span = el.shadowRoot?.querySelector('span');
+    expect(span).to.exist;
+    expect(span?.classList.contains('sr-only')).to.be.true;
+  });
+
+  test('slots any provided text into the span', async () => {
+    const el = await fixture<IASrOnlyText>(
+      html`<ia-sr-only-text>Foo bar</ia-sr-only-text>`,
+    );
+    const slottedElements = el.shadowRoot
+      ?.querySelector('slot')
+      ?.assignedNodes();
+    expect(slottedElements).to.exist;
+    expect(slottedElements?.[0].textContent).to.equal('Foo bar');
+  });
+});

--- a/src/elements/ia-sr-only-text/ia-sr-only-text.ts
+++ b/src/elements/ia-sr-only-text/ia-sr-only-text.ts
@@ -1,0 +1,41 @@
+import { css, CSSResultGroup, html, LitElement, TemplateResult } from 'lit';
+import { customElement } from 'lit/decorators.js';
+
+import themeStyles from '@src/themes/theme-styles';
+
+/**
+ * Wraps any slotted elements in a `span` element that hides them visually but keeps them available for screen readers.
+ * Useful for rendering any additional explanatory text that is only necessary for screen readers.
+ */
+@customElement('ia-sr-only-text')
+export class IASrOnlyText extends LitElement {
+  render(): TemplateResult {
+    return html`
+      <span class="sr-only">
+        <slot></slot>
+      </span>
+    `;
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      themeStyles,
+      css`
+        .sr-only {
+          position: absolute !important;
+          width: 1px !important;
+          height: 1px !important;
+          margin: -1px !important;
+          padding: 0 !important;
+          border: 0 !important;
+          overflow: hidden !important;
+          white-space: nowrap !important;
+          clip: rect(1px, 1px, 1px, 1px) !important;
+          -webkit-clip-path: inset(50%) !important;
+          clip-path: inset(50%) !important;
+          user-select: none !important;
+        }
+      `,
+    ];
+  }
+}


### PR DESCRIPTION
Adds a nice helper element which makes any text slotted into it visible only to screen readers, but not on the page.