### PR TITLE
WEBDEV-8777 Apply ia-button custom active styles for .active class

### DIFF
--- a/src/elements/ia-button/ia-button.ts
+++ b/src/elements/ia-button/ia-button.ts
@@ -352,7 +352,7 @@ export class IAButton extends LitElement {
           border-color: var(--ia-button-custom-border--);
         }
 
-        button.custom:enabled:is(:hover, :focus, :active) {
+        button.custom:enabled:is(:hover, :focus, :active, .active) {
           color: var(--ia-button-custom-active-text-color--);
           background-color: var(--ia-button-custom-active-fill--);
           border-color: var(--ia-button-custom-active-border--);


### PR DESCRIPTION
The custom variant's active-state selector only matched the native :hover/:focus/:active pseudo-classes, so elements that toggle a persistent .active class via JS never got the active styling.

https://webarchive.jira.com/browse/WEBDEV-8777