### PR TITLE
WEBDEV-8888 Fix dropdown-search-bar layering issue in older Safari

### DIFF
--- a/src/elements/ia-dropdown-search-bar/ia-dropdown-search-bar.test.ts
+++ b/src/elements/ia-dropdown-search-bar/ia-dropdown-search-bar.test.ts
@@ -178,6 +178,35 @@ describe('IA Dropdown Search Bar', () => {
     });
   });
 
+  describe('dropdown z-index behavior', () => {
+    // Ensure that we pass an explicit --dropdownListZIndex value to the inner
+    // dropdown component, rather than relying on a CSS-wide keyword that old
+    // Safari may not support correctly in this context.
+    test('provides a concrete default z-index to the inner dropdown', async () => {
+      const dropdown = el.shadowRoot?.querySelector(
+        '#category-dropdown',
+      ) as HTMLElement;
+
+      const listZIndex = getComputedStyle(dropdown)
+        .getPropertyValue('--dropdownListZIndex')
+        .trim();
+      expect(listZIndex).to.equal('2');
+    });
+
+    test('passes a consumer-provided --dropdown-z-index to the inner dropdown', async () => {
+      el.style.setProperty('--dropdown-z-index', '30');
+
+      const dropdown = el.shadowRoot?.querySelector(
+        '#category-dropdown',
+      ) as HTMLElement;
+
+      const listZIndex = getComputedStyle(dropdown)
+        .getPropertyValue('--dropdownListZIndex')
+        .trim();
+      expect(listZIndex).to.equal('30');
+    });
+  });
+
   describe('search submission behavior', () => {
     test('emits searchRequested with query and category on submit', async () => {
       el.query = 'foo';

--- a/src/elements/ia-dropdown-search-bar/ia-dropdown-search-bar.ts
+++ b/src/elements/ia-dropdown-search-bar/ia-dropdown-search-bar.ts
@@ -235,7 +235,10 @@ export class IADropdownSearchBar extends LitElement {
         --search-bar-width--: var(--search-bar-width, 300px);
         --search-bar-internal-padding--: var(--padding-sm, 5px);
         --clear-button-offset--: var(--clear-button-offset, 0);
-        --dropdown-z-index--: var(--dropdown-z-index, initial);
+        /* While it would be nice to fall back to ia-dropdown's own default here by making this var
+           fall back to "initial", older Safari versions don't support that keyword in a var() fallback.
+           So instead we just restate ia-dropdown's current default 2 here as the fallback. */
+        --dropdown-z-index--: var(--dropdown-z-index, 2);
       }
 
       #container {


### PR DESCRIPTION
Older versions of Safari (~<18) are experiencing a bug where the dropdown menu of the `<ia-dropdown-search-bar>` component does not register a nonzero `z-index` by default and can end up being unintentionally rendered behind later content on the page. This stems from how those older versions do not allow keywords like `initial` to be used as `var()` fallback values, breaking the strategy we're currently using to allow fallback to the inner `ia-dropdown`'s default automatically.

This PR works around this by just restating the default `z-index: 2` from `ia-dropdown` as `ia-dropdown-search-bar`'s own fallback value for the dropdown menu. The duplication is not ideal, but the value is unlikely to change frequently and remains fully configurable by consumers.