### PR TITLE
WEBDEV-8897 Upgrade pinned pnpm version to 11.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0-only",
   "types": "./dist/src/elements/index.d.ts",
   "type": "module",
-  "packageManager": "pnpm@11.13.0",
+  "packageManager": "pnpm@11.22.0",
   "engines": {
     "node": ">=24",
     "pnpm": ">=11"


### PR DESCRIPTION
The currently pinned `"packageManager": "pnpm@11.13.0"` appears to be broken upstream. This PR upgrades to `11.22.0` to get installs working again.