### PR TITLE
v0.2.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/elements",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "A web component library from the Internet Archive.",
   "license": "AGPL-3.0-only",
   "types": "./dist/src/elements/index.d.ts",


### PR DESCRIPTION
Version includes bugfix for `<ia-dropdown-search-bar>` menu z-index in older Safari versions. Also upgrades the package to use `pnpm@11.22.0`.