### PR TITLE
WEBDEV-8928: Gitignore .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 .wireit
 /temp
 .idea
+.claude/worktrees/
 /scripts/check-size-out.md
 /playground/p/**/package-lock.json
 /playground/p/scratch/*/


### PR DESCRIPTION
Worktrees go in `.claude/worktrees/<branch-name>/` now, so ignore that path. Ignores just the worktrees dir, not all of `.claude`.

WEBDEV-8928: https://webarchive.jira.com/browse/WEBDEV-8928

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEWomUzGqJ8SazBDMrZEti