### PR TITLE
WEBDEV-8927: Add a focus mode to the elements demo

### DIFF
--- a/demo/app-root.test.ts
+++ b/demo/app-root.test.ts
@@ -44,12 +44,28 @@ describe('AppRoot', () => {
       expect(ids).to.include('elem-ia-button');
     });
 
-    test('highlights the all-elements button', async () => {
+    test('marks the all-elements button as the current view', async () => {
       const el = await appRoot();
 
       const allLink = el.querySelector('#ia-all-link') as HTMLElement;
-      expect(allLink.classList.contains('active')).to.be.true;
+      expect(allLink.classList.contains('current')).to.be.true;
       expect(allLink.getAttribute('aria-current')).to.equal('page');
+    });
+
+    test('marks the scrolled-to element in-view rather than current', async () => {
+      const el = await appRoot();
+
+      await waitUntil(
+        () => el.querySelector('.ia-elem-link.in-view'),
+        'the scroll spy never marked an element',
+      );
+
+      const inView = el.querySelectorAll('.ia-elem-link.in-view');
+      expect(inView.length).to.equal(1);
+      expect(inView[0].getAttribute('aria-current')).to.equal('location');
+      // `current` stays reserved for the view you're on, which here is the
+      // all-elements button, so the two never wear the same treatment.
+      expect(el.querySelectorAll('.ia-elem-link.current').length).to.equal(0);
     });
 
     test('falls back to every element when the hash names an unknown one', async () => {
@@ -86,21 +102,24 @@ describe('AppRoot', () => {
       expect(customElements.get('ia-button-story')).to.exist;
     });
 
-    test('marks only the focused element active in the sidebar', async () => {
+    test('marks only the focused element as the current view', async () => {
       setHash('#elem-ia-button');
       const el = await appRoot();
 
-      const active = el.querySelectorAll('#ia-sidebar .ia-elem-link.active');
-      expect(active.length).to.equal(1);
-      expect(active[0].getAttribute('href')).to.equal('#elem-ia-button');
+      const current = el.querySelectorAll('#ia-sidebar .ia-elem-link.current');
+      expect(current.length).to.equal(1);
+      expect(current[0].getAttribute('href')).to.equal('#elem-ia-button');
+      expect(current[0].getAttribute('aria-current')).to.equal('page');
+      // Nothing is merely scrolled to when only one element is on the page.
+      expect(el.querySelectorAll('.ia-elem-link.in-view').length).to.equal(0);
     });
 
-    test('does not highlight the all-elements button', async () => {
+    test('does not mark the all-elements button', async () => {
       setHash('#elem-ia-button');
       const el = await appRoot();
 
       const allLink = el.querySelector('#ia-all-link') as HTMLElement;
-      expect(allLink.classList.contains('active')).to.be.false;
+      expect(allLink.classList.contains('current')).to.be.false;
       expect(allLink.getAttribute('aria-current')).to.equal('false');
     });
   });

--- a/demo/app-root.test.ts
+++ b/demo/app-root.test.ts
@@ -1,0 +1,148 @@
+import { fixture, fixtureCleanup, waitUntil } from '@open-wc/testing-helpers';
+import { afterEach, describe, expect, test } from 'vitest';
+import { html } from 'lit';
+
+import type { AppRoot } from './app-root';
+import './app-root';
+
+/**
+ * Sets the hash without firing hashchange, so a fixture created afterwards
+ * picks it up as its initial view.
+ */
+function setHash(hash: string) {
+  window.history.replaceState(null, '', hash);
+}
+
+function clearHash() {
+  window.history.replaceState(
+    null,
+    '',
+    window.location.pathname + window.location.search,
+  );
+}
+
+function anchorIds(el: AppRoot): string[] {
+  return Array.from(el.querySelectorAll('.ia-anchor')).map(
+    (anchor) => anchor.id,
+  );
+}
+
+const appRoot = () => fixture<AppRoot>(html`<app-root></app-root>`);
+
+describe('AppRoot', () => {
+  afterEach(() => {
+    fixtureCleanup();
+    clearHash();
+  });
+
+  describe('all-elements view', () => {
+    test('renders every element when there is no hash', async () => {
+      const el = await appRoot();
+
+      const ids = anchorIds(el);
+      expect(ids.length).to.be.greaterThan(1);
+      expect(ids).to.include('elem-ia-button');
+    });
+
+    test('falls back to every element when the hash names an unknown one', async () => {
+      setHash('#elem-not-a-real-element');
+      const el = await appRoot();
+
+      expect(anchorIds(el).length).to.be.greaterThan(1);
+    });
+
+    test('falls back to every element for a hash without the elem- prefix', async () => {
+      setHash('#some-other-anchor');
+      const el = await appRoot();
+
+      expect(anchorIds(el).length).to.be.greaterThan(1);
+    });
+  });
+
+  describe('focused view', () => {
+    test('renders only the element named in the hash', async () => {
+      setHash('#elem-ia-button');
+      const el = await appRoot();
+
+      expect(anchorIds(el)).to.deep.equal(['elem-ia-button']);
+    });
+
+    test('loads the focused story and lets it upgrade', async () => {
+      setHash('#elem-ia-button');
+      const el = await appRoot();
+
+      await waitUntil(
+        () => el.querySelector('ia-button-story'),
+        '<ia-button-story> was never rendered',
+      );
+      expect(customElements.get('ia-button-story')).to.exist;
+    });
+
+    test('marks only the focused element active in the sidebar', async () => {
+      setHash('#elem-ia-button');
+      const el = await appRoot();
+
+      const active = el.querySelectorAll('#ia-sidebar a.active');
+      expect(active.length).to.equal(1);
+      expect(active[0].getAttribute('href')).to.equal('#elem-ia-button');
+    });
+  });
+
+  describe('navigation', () => {
+    test('narrows to one element and back again as the hash changes', async () => {
+      const el = await appRoot();
+      expect(anchorIds(el).length).to.be.greaterThan(1);
+
+      window.location.hash = '#elem-ia-button';
+      await waitUntil(
+        () => anchorIds(el).length === 1,
+        'never narrowed to the focused element',
+      );
+      expect(anchorIds(el)).to.deep.equal(['elem-ia-button']);
+
+      window.location.hash = '';
+      await waitUntil(
+        () => anchorIds(el).length > 1,
+        'never returned to the all-elements view',
+      );
+    });
+
+    test('keeps following the hash after a disconnect and reconnect', async () => {
+      const el = await appRoot();
+      const parent = el.parentElement as HTMLElement;
+
+      parent.removeChild(el);
+      parent.appendChild(el);
+      await el.updateComplete;
+
+      window.location.hash = '#elem-ia-button';
+      await waitUntil(
+        () => anchorIds(el).length === 1,
+        'hash navigation stopped working after reconnecting',
+      );
+      expect(anchorIds(el)).to.deep.equal(['elem-ia-button']);
+    });
+
+    test('picks up a hash that changed while it was detached', async () => {
+      const el = await appRoot();
+      const parent = el.parentElement as HTMLElement;
+
+      parent.removeChild(el);
+      setHash('#elem-ia-button');
+      parent.appendChild(el);
+      await el.updateComplete;
+
+      expect(anchorIds(el)).to.deep.equal(['elem-ia-button']);
+    });
+
+    test('sidebar links address each element by hash', async () => {
+      const el = await appRoot();
+
+      const hrefs = Array.from(el.querySelectorAll('#ia-sidebar a')).map(
+        (link) => link.getAttribute('href'),
+      );
+      expect(hrefs[0]).to.equal('#');
+      expect(hrefs).to.include('#elem-ia-button');
+    });
+  });
+});

--- a/demo/app-root.test.ts
+++ b/demo/app-root.test.ts
@@ -44,6 +44,14 @@ describe('AppRoot', () => {
       expect(ids).to.include('elem-ia-button');
     });
 
+    test('highlights the all-elements button', async () => {
+      const el = await appRoot();
+
+      const allLink = el.querySelector('#ia-all-link') as HTMLElement;
+      expect(allLink.classList.contains('active')).to.be.true;
+      expect(allLink.getAttribute('aria-current')).to.equal('page');
+    });
+
     test('falls back to every element when the hash names an unknown one', async () => {
       setHash('#elem-not-a-real-element');
       const el = await appRoot();
@@ -82,9 +90,18 @@ describe('AppRoot', () => {
       setHash('#elem-ia-button');
       const el = await appRoot();
 
-      const active = el.querySelectorAll('#ia-sidebar a.active');
+      const active = el.querySelectorAll('#ia-sidebar .ia-elem-link.active');
       expect(active.length).to.equal(1);
       expect(active[0].getAttribute('href')).to.equal('#elem-ia-button');
+    });
+
+    test('does not highlight the all-elements button', async () => {
+      setHash('#elem-ia-button');
+      const el = await appRoot();
+
+      const allLink = el.querySelector('#ia-all-link') as HTMLElement;
+      expect(allLink.classList.contains('active')).to.be.false;
+      expect(allLink.getAttribute('aria-current')).to.equal('false');
     });
   });
 

--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -4,15 +4,14 @@ import { customElement, state } from 'lit/decorators.js';
 // Lit's html`` tag cannot render variable tag names directly.
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
+import { HASH_PREFIX, tagFromHash } from './element-hash';
+
 // Globbed without `eager`, so the keys give us the full element list at build
 // time while each module is only fetched when its story is displayed.
 const storyLoaders = import.meta.glob([
   '../src/elements/**/*-story.ts',
   '../src/labs/**/*-story.ts',
 ]);
-
-// Prefix for both the anchor ids and the URL hash, e.g. `#elem-ia-button`.
-const HASH_PREFIX = 'elem-';
 
 interface StoryEntry {
   /** The component's tag name, e.g. `ia-button`. */
@@ -54,8 +53,7 @@ const ALL_ENTRIES = [...productionEntries, ...labsEntries];
  * somewhere useful.
  */
 function entryFromHash(hash: string): StoryEntry | undefined {
-  if (!hash.startsWith(`#${HASH_PREFIX}`)) return undefined;
-  const tag = hash.slice(HASH_PREFIX.length + 1);
+  const tag = tagFromHash(hash);
   return storyEntries.find((e) => e.tag === tag);
 }
 

--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -180,16 +180,19 @@ export class AppRoot extends LitElement {
   private _renderSidebar() {
     const showingAll = !this._focused;
     const activeTag = this._focused ? this._focused.tag : this._activeTag;
-    // `page` when the view really is that one element, `location` when the
-    // highlight only tracks where the all-elements list is scrolled to.
-    const currentKind = showingAll ? 'location' : 'page';
+    // The sidebar marks two different things, so they get different names and
+    // different styling: `current` is the element the view is actually
+    // showing, `in-view` is only where the all-elements list is scrolled to.
+    const [markClass, markAria] = showingAll
+      ? ['in-view', 'location']
+      : ['current', 'page'];
     const link = (entry: StoryEntry) => {
-      const active = entry.tag === activeTag;
+      const marked = entry.tag === activeTag;
       return html`
         <a
           href="#${entry.id}"
-          class="ia-elem-link ${active ? 'active' : ''}"
-          aria-current="${active ? currentKind : 'false'}"
+          class="ia-elem-link ${marked ? markClass : ''}"
+          aria-current="${marked ? markAria : 'false'}"
           >&lt;${entry.tag}&gt;</a
         >
       `;
@@ -200,7 +203,7 @@ export class AppRoot extends LitElement {
         <a
           id="ia-all-link"
           href="#"
-          class="${showingAll ? 'active' : ''}"
+          class="${showingAll ? 'current' : ''}"
           aria-current="${showingAll ? 'page' : 'false'}"
           >Show All Elements</a
         >

--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -178,19 +178,32 @@ export class AppRoot extends LitElement {
   }
 
   private _renderSidebar() {
+    const showingAll = !this._focused;
     const activeTag = this._focused ? this._focused.tag : this._activeTag;
-    const link = (entry: StoryEntry) => html`
-      <a
-        href="#${entry.id}"
-        class="${entry.tag === activeTag ? 'active' : ''}"
-        aria-current="${entry.tag === activeTag ? 'page' : 'false'}"
-        >&lt;${entry.tag}&gt;</a
-      >
-    `;
+    // `page` when the view really is that one element, `location` when the
+    // highlight only tracks where the all-elements list is scrolled to.
+    const currentKind = showingAll ? 'location' : 'page';
+    const link = (entry: StoryEntry) => {
+      const active = entry.tag === activeTag;
+      return html`
+        <a
+          href="#${entry.id}"
+          class="ia-elem-link ${active ? 'active' : ''}"
+          aria-current="${active ? currentKind : 'false'}"
+          >&lt;${entry.tag}&gt;</a
+        >
+      `;
+    };
 
     return html`
       <nav id="ia-sidebar">
-        <a id="ia-all-link" href="#">All elements</a>
+        <a
+          id="ia-all-link"
+          href="#"
+          class="${showingAll ? 'active' : ''}"
+          aria-current="${showingAll ? 'page' : 'false'}"
+          >Show All Elements</a
+        >
         <h2>Production-Ready</h2>
         ${productionEntries.map(link)}
         <h2>Labs 🧪</h2>

--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -1,104 +1,238 @@
-import { html, LitElement } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { html, LitElement, type TemplateResult } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
 // unsafeHTML is needed to render dynamic custom-element tag names;
 // Lit's html`` tag cannot render variable tag names directly.
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 
-const storyModules = import.meta.glob(
-  ['../src/elements/**/*-story.ts', '../src/labs/**/*-story.ts'],
-  { eager: true }
-);
+// Globbed without `eager`, so the keys give us the full element list at build
+// time while each module is only fetched when its story is displayed.
+const storyLoaders = import.meta.glob([
+  '../src/elements/**/*-story.ts',
+  '../src/labs/**/*-story.ts',
+]);
 
-const storyEntries = Object.keys(storyModules)
-  .map(path => {
-    const labs = path.includes('/src/labs/');
+// Prefix for both the anchor ids and the URL hash, e.g. `#elem-ia-button`.
+const HASH_PREFIX = 'elem-';
+
+interface StoryEntry {
+  /** The component's tag name, e.g. `ia-button`. */
+  tag: string;
+  /** The story wrapper's tag name, e.g. `ia-button-story`. */
+  storyTag: string;
+  /** Anchor id and hash fragment, e.g. `elem-ia-button`. */
+  id: string;
+  labs: boolean;
+  load: () => Promise<unknown>;
+}
+
+type LoadState = 'loading' | 'loaded' | 'error';
+
+const storyEntries: StoryEntry[] = Object.keys(storyLoaders)
+  .map((path) => {
     const parts = path.split('/');
     const filename = parts[parts.length - 1]; // e.g. "ia-button-story.ts"
     const tag = filename.replace(/-story\.ts$/, '');
-    return { tag, storyTag: `${tag}-story`, id: `elem-${tag}`, labs };
+    return {
+      tag,
+      storyTag: `${tag}-story`,
+      id: `${HASH_PREFIX}${tag}`,
+      labs: path.includes('/src/labs/'),
+      load: storyLoaders[path],
+    };
   })
   .sort((a, b) => a.tag.localeCompare(b.tag));
 
-const productionEntries = storyEntries.filter(e => !e.labs);
-const labsEntries = storyEntries.filter(e => e.labs);
+const productionEntries = storyEntries.filter((e) => !e.labs);
+const labsEntries = storyEntries.filter((e) => e.labs);
+// Document order in the all-elements view, which the scroll spy relies on.
 const ALL_ENTRIES = [...productionEntries, ...labsEntries];
+
+/**
+ * Resolves a URL hash to the element it focuses, or null for the
+ * all-elements view. Hashes naming an unknown element also fall back to the
+ * all-elements view, so links to renamed or removed elements still land
+ * somewhere useful.
+ */
+function entryFromHash(hash: string): StoryEntry | undefined {
+  if (!hash.startsWith(`#${HASH_PREFIX}`)) return undefined;
+  const tag = hash.slice(HASH_PREFIX.length + 1);
+  return storyEntries.find((e) => e.tag === tag);
+}
 
 @customElement('app-root')
 export class AppRoot extends LitElement {
-  createRenderRoot() { return this; }
-
-  private _observer?: IntersectionObserver;
-  private _abortController = new AbortController();
-
-  render() {
-    return html`
-      <nav id="ia-sidebar">
-        <h2>Production-Ready</h2>
-        ${productionEntries.map(e => html`<a href="#${e.id}">&lt;${e.tag}&gt;</a>`)}
-        <h2>Labs 🧪</h2>
-        ${labsEntries.map(e => html`<a href="#${e.id}">&lt;${e.tag}&gt;</a>`)}
-      </nav>
-      <div id="ia-content">
-        <h1>Internet Archive Elements</h1>
-        <h2>Production-Ready Elements</h2>
-        ${productionEntries.map(e => html`
-          <div id="${e.id}" class="ia-anchor">
-            ${unsafeHTML(`<${e.storyTag}></${e.storyTag}>`)}
-          </div>
-        `)}
-        <h2>Labs Elements</h2>
-        ${labsEntries.map(e => html`
-          <div id="${e.id}" class="ia-anchor">
-            ${unsafeHTML(`<${e.storyTag}></${e.storyTag}>`)}
-          </div>
-        `)}
-      </div>
-    `;
+  createRenderRoot() {
+    return this;
   }
 
-  firstUpdated() {
-    const allIds = ALL_ENTRIES.map(e => e.id);
+  /** The element the URL focuses, or undefined to show all of them. */
+  @state() private _focused = entryFromHash(window.location.hash);
 
-    const links = Object.fromEntries(
-      allIds.map(id => [id, this.querySelector(`#ia-sidebar a[href="#${id}"]`)])
-    );
+  /** Sidebar highlight in the all-elements view, driven by scroll position. */
+  @state() private _activeTag?: string;
 
-    const visible = new Set<string>();
+  // Plain map rather than reactive state: Lit doesn't observe mutation, so
+  // _loadStory requests its own update once a module settles.
+  private _loadStates = new Map<string, LoadState>();
 
-    // Only anchors in the top 30% of the viewport count as "active".
-    // The first (topmost) visible anchor wins.
-    this._observer = new IntersectionObserver(
-      entries => {
-        for (const entry of entries) {
-          if (entry.isIntersecting) visible.add(entry.target.id);
-          else visible.delete(entry.target.id);
-        }
-        const activeId = allIds.find(id => visible.has(id)) ?? allIds[0];
-        allIds.forEach(id => links[id]?.classList.toggle('active', id === activeId));
-      },
-      { rootMargin: '0px 0px -70% 0px' },
-    );
+  private _observer?: IntersectionObserver;
+  private _abortController?: AbortController;
 
-    allIds.forEach(id => {
-      const el = document.getElementById(id);
-      if (el) this._observer!.observe(el);
-    });
-
-    allIds.forEach(id => {
-      links[id]?.addEventListener('click', (e: Event) => {
-        e.preventDefault();
-        const el = document.getElementById(id);
-        if (el) {
-          const top = el.getBoundingClientRect().top + window.scrollY;
-          window.scrollTo({ top: Math.max(0, top - 16), behavior: 'smooth' });
-        }
-      }, { signal: this._abortController.signal });
+  connectedCallback() {
+    super.connectedCallback();
+    // Built per connection, since aborting on disconnect spends the controller
+    // and its signal is what holds the listener open.
+    this._abortController = new AbortController();
+    // The hash can move while this element is detached.
+    this._focused = entryFromHash(window.location.hash);
+    window.addEventListener('hashchange', this._onHashChange, {
+      signal: this._abortController.signal,
     });
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
+    this._disconnectScrollSpy();
+    this._abortController?.abort();
+  }
+
+  private _onHashChange = () => {
+    const focused = entryFromHash(window.location.hash);
+    if (focused === this._focused) return;
+    this._focused = focused;
+    // Cleared alongside _focused so both land in a single render: whichever
+    // view we arrive at, the old scroll-driven highlight no longer applies.
+    this._activeTag = undefined;
+    // The browser's own anchor jump ran before this view existed, so put the
+    // new one at the top of the page rather than wherever the last scroll left it.
+    window.scrollTo({ top: 0 });
+  };
+
+  willUpdate() {
+    const needed = this._focused ? [this._focused] : ALL_ENTRIES;
+    needed.forEach((entry) => this._loadStory(entry));
+  }
+
+  updated() {
+    if (this._focused) this._disconnectScrollSpy();
+    else this._setUpScrollSpy();
+  }
+
+  private async _loadStory(entry: StoryEntry) {
+    if (this._loadStates.has(entry.tag)) return;
+    this._loadStates.set(entry.tag, 'loading');
+    try {
+      await entry.load();
+      this._loadStates.set(entry.tag, 'loaded');
+    } catch (err) {
+      console.error(`Could not load the story for <${entry.tag}>`, err);
+      this._loadStates.set(entry.tag, 'error');
+    }
+    this.requestUpdate();
+  }
+
+  /**
+   * Highlights the sidebar link for whichever anchor sits nearest the top of
+   * the viewport. Only meaningful when every element is on the page.
+   */
+  private _setUpScrollSpy() {
+    if (this._observer) return;
+
+    const visibleIds = new Set<string>();
+    this._observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) visibleIds.add(entry.target.id);
+          else visibleIds.delete(entry.target.id);
+        }
+        // Only anchors in the top 30% of the viewport count as "active".
+        // The first (topmost) visible anchor wins.
+        const active = ALL_ENTRIES.find((e) => visibleIds.has(e.id));
+        this._activeTag = (active ?? ALL_ENTRIES[0])?.tag;
+      },
+      { rootMargin: '0px 0px -70% 0px' },
+    );
+
+    for (const entry of ALL_ENTRIES) {
+      const el = this.querySelector(`#${entry.id}`);
+      if (el) this._observer.observe(el);
+    }
+  }
+
+  // Called from updated(), so it deliberately touches no reactive state.
+  private _disconnectScrollSpy() {
     this._observer?.disconnect();
-    this._abortController.abort();
+    this._observer = undefined;
+  }
+
+  render() {
+    return html`
+      ${this._renderSidebar()}
+      <div id="ia-content" class="${this._focused ? 'ia-focused' : ''}">
+        <h1>Internet Archive Elements</h1>
+        ${this._focused
+          ? this._renderFocused(this._focused)
+          : this._renderAll()}
+      </div>
+    `;
+  }
+
+  private _renderSidebar() {
+    const activeTag = this._focused ? this._focused.tag : this._activeTag;
+    const link = (entry: StoryEntry) => html`
+      <a
+        href="#${entry.id}"
+        class="${entry.tag === activeTag ? 'active' : ''}"
+        aria-current="${entry.tag === activeTag ? 'page' : 'false'}"
+        >&lt;${entry.tag}&gt;</a
+      >
+    `;
+
+    return html`
+      <nav id="ia-sidebar">
+        <a id="ia-all-link" href="#">All elements</a>
+        <h2>Production-Ready</h2>
+        ${productionEntries.map(link)}
+        <h2>Labs 🧪</h2>
+        ${labsEntries.map(link)}
+      </nav>
+    `;
+  }
+
+  private _renderFocused(entry: StoryEntry): TemplateResult {
+    return html`
+      <h2>${entry.labs ? 'Labs Element' : 'Production-Ready Element'}</h2>
+      ${this._renderStory(entry)}
+    `;
+  }
+
+  private _renderAll(): TemplateResult {
+    return html`
+      <h2>Production-Ready Elements</h2>
+      ${productionEntries.map((e) => this._renderStory(e))}
+      <h2>Labs Elements</h2>
+      ${labsEntries.map((e) => this._renderStory(e))}
+    `;
+  }
+
+  private _renderStory(entry: StoryEntry): TemplateResult {
+    const loadState = this._loadStates.get(entry.tag);
+
+    let contents;
+    if (loadState === 'loaded') {
+      contents = unsafeHTML(`<${entry.storyTag}></${entry.storyTag}>`);
+    } else if (loadState === 'error') {
+      contents = html`
+        <p class="ia-story-message">
+          Could not load &lt;${entry.tag}&gt;. Check the console for details.
+        </p>
+      `;
+    } else {
+      contents = html`
+        <p class="ia-story-message">Loading &lt;${entry.tag}&gt;…</p>
+      `;
+    }
+
+    return html`<div id="${entry.id}" class="ia-anchor">${contents}</div>`;
   }
 }

--- a/demo/element-hash.ts
+++ b/demo/element-hash.ts
@@ -1,0 +1,18 @@
+/**
+ * How the demo addresses a single element through the URL hash. Both the
+ * router and the story template need to agree on the spelling, and this
+ * module imports nothing so either can pull it in without a cycle.
+ */
+
+/** Prefix for both the anchor ids and the URL hash, e.g. `#elem-ia-button`. */
+export const HASH_PREFIX = 'elem-';
+
+/**
+ * The element tag a hash addresses, or undefined when it addresses none. The
+ * tag isn't checked against the elements that exist, so a hash naming a
+ * removed element yields a tag that nothing matches.
+ */
+export function tagFromHash(hash: string): string | undefined {
+  if (!hash.startsWith(`#${HASH_PREFIX}`)) return undefined;
+  return hash.slice(HASH_PREFIX.length + 1) || undefined;
+}

--- a/demo/index.css
+++ b/demo/index.css
@@ -72,14 +72,6 @@ app-root {
   color: #213547;
 }
 
-/* Filled rather than the tinted treatment the element links use, so the view
-   you're in stays distinct from the scroll position within it. */
-#ia-all-link.active {
-  background: #194880;
-  border-color: #194880;
-  color: #fff;
-}
-
 #ia-sidebar h2 {
   font-size: 0.7rem;
   font-weight: 600;
@@ -116,10 +108,23 @@ app-root {
   color: #213547;
 }
 
-#ia-sidebar .ia-elem-link.active {
+/* Where the all-elements list happens to be scrolled to. Tinted, so it reads
+   as a position marker rather than as the thing you're looking at. */
+#ia-sidebar .ia-elem-link.in-view {
   color: #194880;
   border-left-color: #194880;
   background: #f0f4f9;
+  font-weight: 600;
+}
+
+/* The view you're actually on, whether that's every element or just one. A
+   filled row means "this is the view" wherever it appears in the sidebar.
+   Last, so it wins the specificity tie against the :hover rules above. */
+#ia-all-link.current,
+#ia-sidebar .ia-elem-link.current {
+  color: #fff;
+  background: #194880;
+  border-color: #194880;
   font-weight: 600;
 }
 

--- a/demo/index.css
+++ b/demo/index.css
@@ -46,13 +46,38 @@ app-root {
   overflow-y: auto;
 }
 
-#ia-sidebar #ia-all-link {
-  font-weight: 600;
+/* Styled as a button, since it swaps the whole view rather than jumping to an
+   anchor like the element links below it do. */
+#ia-all-link {
+  display: block;
+  margin: 0 1rem 1.5rem;
+  padding: 0.4rem 0.75rem;
+  border: 1px solid #bbb;
+  border-radius: 4px;
+  background: #fff;
   color: #213547;
-  margin-bottom: 0.75rem;
-  padding-bottom: 0.6rem;
-  border-bottom: 1px solid #ddd;
-  border-left-color: transparent;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-align: center;
+  text-decoration: none;
+  transition:
+    background 0.1s,
+    color 0.1s,
+    border-color 0.1s;
+}
+
+#ia-all-link:hover {
+  background: #f0f0f0;
+  border-color: #767676;
+  color: #213547;
+}
+
+/* Filled rather than the tinted treatment the element links use, so the view
+   you're in stays distinct from the scroll position within it. */
+#ia-all-link.active {
+  background: #194880;
+  border-color: #194880;
+  color: #fff;
 }
 
 #ia-sidebar h2 {
@@ -62,10 +87,14 @@ app-root {
   letter-spacing: 0.08em;
   color: #767676;
   padding: 0 1rem;
-  margin: 0 0 0.5rem;
+  margin: 1.5rem 0 0.5rem;
 }
 
-#ia-sidebar a {
+#ia-sidebar h2:first-of-type {
+  margin-top: 0;
+}
+
+#ia-sidebar .ia-elem-link {
   display: block;
   font-size: 0.82rem;
   font-weight: 400;
@@ -73,18 +102,21 @@ app-root {
   text-decoration: none;
   padding: 0.3rem 1rem;
   border-left: 3px solid transparent;
-  transition: background 0.1s, color 0.1s, border-color 0.1s;
+  transition:
+    background 0.1s,
+    color 0.1s,
+    border-color 0.1s;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-#ia-sidebar a:hover {
+#ia-sidebar .ia-elem-link:hover {
   background: #f0f0f0;
   color: #213547;
 }
 
-#ia-sidebar a.active {
+#ia-sidebar .ia-elem-link.active {
   color: #194880;
   border-left-color: #194880;
   background: #f0f4f9;

--- a/demo/index.css
+++ b/demo/index.css
@@ -46,6 +46,15 @@ app-root {
   overflow-y: auto;
 }
 
+#ia-sidebar #ia-all-link {
+  font-weight: 600;
+  color: #213547;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid #ddd;
+  border-left-color: transparent;
+}
+
 #ia-sidebar h2 {
   font-size: 0.7rem;
   font-weight: 600;
@@ -89,6 +98,10 @@ app-root {
   min-width: 0;
 }
 
+#ia-content.ia-focused {
+  padding-bottom: 2rem;
+}
+
 .ia-anchor {
   scroll-margin-top: 16px;
 }
@@ -109,4 +122,10 @@ app-root {
   font-size: 1.1rem;
   font-weight: 600;
   margin: 0.75rem 0 0.25rem;
+}
+
+.ia-story-message {
+  font-size: 0.9rem;
+  color: #767676;
+  margin: 0.5rem 0;
 }

--- a/demo/story-template.test.ts
+++ b/demo/story-template.test.ts
@@ -5,6 +5,22 @@ import { html } from 'lit';
 import type { StoryTemplate } from './story-template';
 import './story-template';
 
+/**
+ * Sets the hash without firing hashchange, so a fixture created afterwards
+ * picks it up as its initial view.
+ */
+function setHash(hash: string) {
+  window.history.replaceState(null, '', hash);
+}
+
+function clearHash() {
+  window.history.replaceState(
+    null,
+    '',
+    window.location.pathname + window.location.search,
+  );
+}
+
 describe('StoryTemplate', () => {
   describe('importCode', () => {
     test('includes both side-effect and named import when elementClassName is provided', async () => {
@@ -153,6 +169,61 @@ describe('StoryTemplate', () => {
       await el.updateComplete;
       expect(details?.classList.contains('collapsed')).to.be.true;
       expect(details?.classList.contains('expanded')).to.be.false;
+    });
+  });
+
+  describe('Details in the focused view', () => {
+    afterEach(() => {
+      clearHash();
+    });
+
+    const detailsFor = (el: StoryTemplate) =>
+      el.shadowRoot?.querySelector('#details');
+
+    test('starts expanded when the hash focuses this element', async () => {
+      setHash('#elem-ia-button');
+      const el = await fixture<StoryTemplate>(html`
+        <story-template elementTag="ia-button"></story-template>
+      `);
+
+      expect(detailsFor(el)?.classList.contains('expanded')).to.be.true;
+    });
+
+    test('starts collapsed when the hash focuses a different element', async () => {
+      setHash('#elem-ia-combo-box');
+      const el = await fixture<StoryTemplate>(html`
+        <story-template elementTag="ia-button"></story-template>
+      `);
+
+      expect(detailsFor(el)?.classList.contains('collapsed')).to.be.true;
+    });
+
+    test('starts collapsed for a hash that names no element', async () => {
+      setHash('#some-other-anchor');
+      const el = await fixture<StoryTemplate>(html`
+        <story-template elementTag="ia-button"></story-template>
+      `);
+
+      expect(detailsFor(el)?.classList.contains('collapsed')).to.be.true;
+    });
+
+    test('leaves a section the reader closed alone on later renders', async () => {
+      setHash('#elem-ia-button');
+      const el = await fixture<StoryTemplate>(html`
+        <story-template elementTag="ia-button"></story-template>
+      `);
+      expect(detailsFor(el)?.classList.contains('expanded')).to.be.true;
+
+      const toggleBtn = el.shadowRoot?.querySelector(
+        '.details-toggle',
+      ) as HTMLButtonElement;
+      toggleBtn.click();
+      await el.updateComplete;
+      expect(detailsFor(el)?.classList.contains('collapsed')).to.be.true;
+
+      el.elementClassName = 'IAButton';
+      await el.updateComplete;
+      expect(detailsFor(el)?.classList.contains('collapsed')).to.be.true;
     });
   });
 

--- a/demo/story-template.test.ts
+++ b/demo/story-template.test.ts
@@ -207,6 +207,32 @@ describe('StoryTemplate', () => {
       expect(detailsFor(el)?.classList.contains('collapsed')).to.be.true;
     });
 
+    const maxHeightFor = (el: StoryTemplate) => {
+      const highlighter = el.shadowRoot?.querySelector(
+        'syntax-highlighter',
+      ) as HTMLElement;
+      return getComputedStyle(highlighter)
+        .getPropertyValue('--syntax-max-height')
+        .trim();
+    };
+
+    test('lets the code snippets run full height when focused', async () => {
+      setHash('#elem-ia-button');
+      const el = await fixture<StoryTemplate>(html`
+        <story-template elementTag="ia-button"></story-template>
+      `);
+
+      expect(maxHeightFor(el)).to.equal('none');
+    });
+
+    test('keeps the code snippets capped when not focused', async () => {
+      const el = await fixture<StoryTemplate>(html`
+        <story-template elementTag="ia-button"></story-template>
+      `);
+
+      expect(maxHeightFor(el)).to.equal('5.5rem');
+    });
+
     test('leaves a section the reader closed alone on later renders', async () => {
       setHash('#elem-ia-button');
       const el = await fixture<StoryTemplate>(html`

--- a/demo/story-template.ts
+++ b/demo/story-template.ts
@@ -1,4 +1,10 @@
-import { css, html, LitElement, type CSSResultGroup } from 'lit';
+import {
+  css,
+  html,
+  LitElement,
+  type CSSResultGroup,
+  type PropertyValues,
+} from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { customElement } from 'lit/decorators/custom-element.js';
 import { when } from 'lit/directives/when.js';
@@ -11,6 +17,8 @@ import type {
   AppliedProps,
   PropInputData,
 } from './story-components/story-prop-settings';
+
+import { tagFromHash } from './element-hash';
 
 import testTube from './test-tube.svg';
 
@@ -40,6 +48,7 @@ export class StoryTemplate extends LitElement {
 
   @property({ type: Boolean }) labs = false;
 
+  /* Whether the Import, Usage & Settings section is expanded */
   @state() private detailsVisible = false;
 
   /* Stringified styles applied for the demo component */
@@ -60,6 +69,17 @@ export class StoryTemplate extends LitElement {
   /* Tracks which copy button was last clicked, for feedback */
   @state() private copiedKey: 'import' | 'usage' | 'styling' | null = null;
   private _copyTimeout?: ReturnType<typeof setTimeout>;
+
+  willUpdate(changedProperties: PropertyValues) {
+    // Start expanded when the demo is showing this element on its own, since
+    // it is then the only thing on the page and nothing is buried under it.
+    // Only on the first read of elementTag, so a later render can't reopen a
+    // section the reader has closed.
+    if (changedProperties.has('elementTag')) {
+      this.detailsVisible =
+        this.elementTag === tagFromHash(window.location.hash);
+    }
+  }
 
   render() {
     return html`

--- a/demo/story-template.ts
+++ b/demo/story-template.ts
@@ -48,6 +48,9 @@ export class StoryTemplate extends LitElement {
 
   @property({ type: Boolean }) labs = false;
 
+  /* Whether the demo is showing this element on its own */
+  @state() private focused = false;
+
   /* Whether the Import, Usage & Settings section is expanded */
   @state() private detailsVisible = false;
 
@@ -71,13 +74,12 @@ export class StoryTemplate extends LitElement {
   private _copyTimeout?: ReturnType<typeof setTimeout>;
 
   willUpdate(changedProperties: PropertyValues) {
-    // Start expanded when the demo is showing this element on its own, since
-    // it is then the only thing on the page and nothing is buried under it.
-    // Only on the first read of elementTag, so a later render can't reopen a
-    // section the reader has closed.
     if (changedProperties.has('elementTag')) {
-      this.detailsVisible =
-        this.elementTag === tagFromHash(window.location.hash);
+      this.focused = this.elementTag === tagFromHash(window.location.hash);
+      // Start expanded when this is the only element on the page, since
+      // nothing is buried under it. Only on the first read of elementTag, so
+      // a later render can't reopen a section the reader has closed.
+      this.detailsVisible = this.focused;
     }
   }
 
@@ -116,7 +118,9 @@ export class StoryTemplate extends LitElement {
           id="details"
           class="${this.detailsVisible ? 'expanded' : 'collapsed'}"
         >
-          <div class="details-inner">${this.detailsTemplate}</div>
+          <div class="details-inner ${this.focused ? 'focused' : ''}">
+            ${this.detailsTemplate}
+          </div>
         </div>
       </div>
     `;
@@ -442,6 +446,13 @@ export class StoryTemplate extends LitElement {
         .details-inner syntax-highlighter {
           display: block;
           --syntax-max-height: 5.5rem;
+        }
+
+        /* One element on the page means nothing else is competing for the
+           height, so let the snippets run their full length rather than
+           scroll inside a short box. */
+        .details-inner.focused syntax-highlighter {
+          --syntax-max-height: none;
         }
 
         .labs-icon {


### PR DESCRIPTION
The demo showed every element on one page. Now `#elem-<tag>` shows just that one, the sidebar switches the focused element instead of scrolling to it, and "All elements" goes back to the full list. Story modules load lazily, so a deep link only fetches that element's chunk.

Hash routing because the demo ships to GH Pages under a base path it doesn't know at build time, so a real path would 404 on reload.

WEBDEV-8927: https://webarchive.jira.com/browse/WEBDEV-8927

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEWomUzGqJ8SazBDMrZEti