### PR TITLE
WEBDEV-8971: Run lint in CI and fix prettier on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,23 @@ on:
     branches: [ main ]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v4
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 24
+        cache: pnpm
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile
+
+    - name: Lint
+      run: pnpm run lint
+
   build:
     runs-on: ubuntu-latest
 

--- a/demo/story-template.test.ts
+++ b/demo/story-template.test.ts
@@ -84,7 +84,8 @@ describe('StoryTemplate', () => {
       `);
 
       // Only import + usage highlighters; styling section is absent when cssCode is empty
-      const highlighters = el.shadowRoot?.querySelectorAll('syntax-highlighter');
+      const highlighters =
+        el.shadowRoot?.querySelectorAll('syntax-highlighter');
       expect(highlighters?.length).to.equal(2);
     });
 
@@ -96,13 +97,12 @@ describe('StoryTemplate', () => {
       (el as any).stringifiedStyles = 'color: red;';
       await el.updateComplete;
 
-      const highlighters = el.shadowRoot?.querySelectorAll('syntax-highlighter');
+      const highlighters =
+        el.shadowRoot?.querySelectorAll('syntax-highlighter');
       expect(highlighters?.length).to.equal(3);
 
       const stylingHighlighter = highlighters?.[2] as any;
-      expect(stylingHighlighter.code).to.equal(
-        'ia-button {\n color: red;\n}',
-      );
+      expect(stylingHighlighter.code).to.equal('ia-button {\n color: red;\n}');
     });
 
     test('has no trailing whitespace on any line', async () => {
@@ -113,7 +113,8 @@ describe('StoryTemplate', () => {
       (el as any).stringifiedStyles = '--my-var: blue;';
       await el.updateComplete;
 
-      const highlighters = el.shadowRoot?.querySelectorAll('syntax-highlighter');
+      const highlighters =
+        el.shadowRoot?.querySelectorAll('syntax-highlighter');
       const code: string = (highlighters?.[2] as any).code;
       for (const line of code.split('\n')) {
         expect(line).to.equal(line.trimEnd());

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,7 +42,7 @@ export default [
     },
   },
   {
-    ignores: ['**/*.js', '**/*.mjs', '**/*.d.ts'],
+    ignores: ['**/*.js', '**/*.mjs', '**/*.d.ts', '.claude/', '.wireit/'],
   },
   {
     files: ['**/*.test.ts'],


### PR DESCRIPTION
CI never ran `pnpm run lint`, so main sat failing prettier on `demo/story-template.test.ts`. This adds a lint job to ci.yml, fixes the formatting, and ignores `.claude/` and `.wireit/` in eslint so local junk doesn't fail the lint (prettier already skips them via .gitignore).

https://webarchive.jira.com/browse/WEBDEV-8971

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUM1e29MLyK3kBDiZYgERx