### PR TITLE
WEBDEV-8972: Run CI on PRs based on any branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: App CI
 on:
   push:
     branches: [ main ]
+  # No branches filter here on purpose: it matches the PR's base branch, so
+  # filtering on main would skip any PR stacked on another PR's branch.
   pull_request:
-    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
`pull_request: branches: [main]` filters on the PR's *base* branch, so any PR stacked on another PR's branch ran no tests at all. It only got deploy-preview, which has no filter. The tests did eventually run once GitHub retargeted the PR to main, but that's after review, so a reviewer in the middle of a stack saw a green PR that was never tested. Live example: PR #82 has no build job.

Dropping the filter from `pull_request` fixes it. Kept the push filter so post-merge runs stay on main only.

One correction to the ticket: CodeQL isn't affected. It's not a workflow in this repo, it's GitHub's managed Code Quality (`dynamic/github-code-quality/codeql`), which has no branch filter and does run on stacked PRs (see PR #82, where it passed).

https://webarchive.jira.com/browse/WEBDEV-8972

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUM1e29MLyK3kBDiZYgERx