### PR TITLE
WEBDEV-8973: Rebuild the demo scroll spy on reconnect

### DIFF
--- a/demo/app-root.test.ts
+++ b/demo/app-root.test.ts
@@ -27,12 +27,24 @@ function anchorIds(el: AppRoot): string[] {
   );
 }
 
+/** The sidebar link the scroll spy currently marks, by href. */
+function inViewHref(el: AppRoot): string | null {
+  const marked = el.querySelector('.ia-elem-link.in-view');
+  return marked ? marked.getAttribute('href') : null;
+}
+
+function scrollToAnchor(el: AppRoot, id: string) {
+  el.querySelector(`#${id}`)?.scrollIntoView();
+}
+
 const appRoot = () => fixture<AppRoot>(html`<app-root></app-root>`);
 
 describe('AppRoot', () => {
   afterEach(() => {
     fixtureCleanup();
     clearHash();
+    // Tests that scroll would otherwise leave the next one part-way down.
+    window.scrollTo({ top: 0 });
   });
 
   describe('all-elements view', () => {
@@ -157,6 +169,59 @@ describe('AppRoot', () => {
         'hash navigation stopped working after reconnecting',
       );
       expect(anchorIds(el)).to.deep.equal(['elem-ia-button']);
+    });
+
+    test('keeps the scroll spy working after reconnecting with no hash change', async () => {
+      const el = await appRoot();
+      const parent = el.parentElement as HTMLElement;
+      const ids = anchorIds(el);
+      const firstId = ids[0];
+      await waitUntil(
+        () => inViewHref(el) === `#${firstId}`,
+        'the scroll spy never marked the first element',
+      );
+
+      // Every story has to have settled before the disconnect below. Each one
+      // requests an update as it lands, and any still in flight would rebuild
+      // the scroll spy on its own, hiding whether reconnecting rebuilt it.
+      // A story that fails to import keeps a message too, so this waits on the
+      // console as much as on the clock. The timeout covers loading all eight
+      // modules cold, which is what happens when this test runs on its own.
+      await waitUntil(
+        () => el.querySelectorAll('.ia-story-message').length === 0,
+        'the stories never all settled; check the console for one that failed to import',
+        { timeout: 5000 },
+      );
+      await el.updateComplete;
+
+      // Loaded stories are also what make the page taller than the viewport.
+      // Without that, scrolling is a no-op and the assertions below would
+      // blame the scroll spy for a page that simply never moved.
+      await waitUntil(
+        () => document.documentElement.scrollHeight > window.innerHeight,
+        'the page never grew tall enough to scroll',
+      );
+
+      // Move the highlight off the first element, so a spy that comes back
+      // dead is distinguishable from one that never had to do anything. How
+      // far down the last anchor gets depends on the page height, so this only
+      // asserts the highlight moved, not where it landed.
+      scrollToAnchor(el, ids[ids.length - 1]);
+      expect(window.scrollY, 'the page did not scroll').to.be.greaterThan(0);
+      await waitUntil(
+        () => inViewHref(el) !== `#${firstId}`,
+        'the scroll spy never followed the scroll away from the first element',
+      );
+
+      parent.removeChild(el);
+      parent.appendChild(el);
+      await el.updateComplete;
+
+      window.scrollTo({ top: 0 });
+      await waitUntil(
+        () => inViewHref(el) === `#${firstId}`,
+        'the scroll spy stopped following the scroll after reconnecting',
+      );
     });
 
     test('picks up a hash that changed while it was detached', async () => {

--- a/demo/app-root.ts
+++ b/demo/app-root.ts
@@ -86,6 +86,10 @@ export class AppRoot extends LitElement {
     window.addEventListener('hashchange', this._onHashChange, {
       signal: this._abortController.signal,
     });
+    // updated() owns the scroll spy, and disconnecting tore it down. An
+    // unchanged hash resolves to the same StoryEntry object, so the assignment
+    // above requests no update on its own, which would leave the spy dead.
+    this.requestUpdate();
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
`AppRoot` tore the scroll spy down on disconnect but could only build it back up from `updated()`, so the sidebar's in-view highlight stayed dead after a reconnect.

The reason it never fired is subtle: `entryFromHash` returns `storyEntries.find(...)`, so an unchanged hash resolves to the *same* object. Lit's default `hasChanged` is `!==`, so re-reading the hash in `connectedCallback` requested no update, `updated()` never ran, and the observer was never rebuilt. Fixed with an explicit `requestUpdate()`, which keeps `updated()` as the single owner of the spy's lifecycle.

app-root is the demo's root element and isn't shipped in the package, so this mainly bites tests and anything that moves the element around the DOM.

Worth knowing about the test: it settles every story load before disconnecting. Without that it passed even with the bug present, because in a cold run the in-flight `_loadStory` calls request their own updates and rebuild the spy by accident. I checked it fails without the fix and passes with it, both on its own and in a full-file run.

https://webarchive.jira.com/browse/WEBDEV-8973

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CUM1e29MLyK3kBDiZYgERx