### PR TITLE
WEBDEV-8972: Run CI on every PR, not just ones based on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: App CI
 on:
   push:
     branches: [ main ]
+  # Deliberately unfiltered. A branch filter here matches the PR's base, not
+  # its head, so filtering on main skips every PR in a stack, where each one
+  # is based on the PR below it rather than on main.
   pull_request:
-    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
[WEBDEV-8972](https://webarchive.jira.com/browse/WEBDEV-8972).

The `pull_request` branch filter matches the PR's **base** branch, so a PR based on another branch never ran the tests at all — only `deploy-preview`, which has no filter.

That's every stacked PR. Live example before this change: [#85](https://github.com/internetarchive/elements/pull/85) is based on [#84](https://github.com/internetarchive/elements/pull/84)'s branch and its only check is `deploy-preview`, while [#77](https://github.com/internetarchive/elements/pull/77), based on `main`, gets all three.

The tests do eventually run, because GitHub retargets each PR to `main` as the one below it merges — but that's after review, so a reviewer looking at the middle of a stack sees a green PR that was never tested.

`push` stays filtered to `main`.

This unblocks the [WEBDEV-8962](https://webarchive.jira.com/browse/WEBDEV-8962) radio player stack ([#77](https://github.com/internetarchive/elements/pull/77)–[#86](https://github.com/internetarchive/elements/pull/86)), where seven of the eight PRs currently show only a preview deploy.

[WEBDEV-8972]: https://webarchive.jira.com/browse/WEBDEV-8972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEBDEV-8962]: https://webarchive.jira.com/browse/WEBDEV-8962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ