### PR TITLE
WEBDEV-9009: Fix the demo scroll spy test on a taller demo page

### DIFF
--- a/demo/app-root.test.ts
+++ b/demo/app-root.test.ts
@@ -176,16 +176,12 @@ describe('AppRoot', () => {
       const parent = el.parentElement as HTMLElement;
       const ids = anchorIds(el);
       const firstId = ids[0];
-      await waitUntil(
-        () => inViewHref(el) === `#${firstId}`,
-        'the scroll spy never marked the first element',
-      );
 
       // Every story has to have settled before the disconnect below. Each one
       // requests an update as it lands, and any still in flight would rebuild
       // the scroll spy on its own, hiding whether reconnecting rebuilt it.
       // A story that fails to import keeps a message too, so this waits on the
-      // console as much as on the clock. The timeout covers loading all eight
+      // console as much as on the clock. The timeout covers loading all the
       // modules cold, which is what happens when this test runs on its own.
       await waitUntil(
         () => el.querySelectorAll('.ia-story-message').length === 0,
@@ -200,6 +196,15 @@ describe('AppRoot', () => {
       await waitUntil(
         () => document.documentElement.scrollHeight > window.innerHeight,
         'the page never grew tall enough to scroll',
+      );
+
+      // The otp-input story puts focus in its first field as it loads, which
+      // scrolls the page down to it. Start from the top instead, so the spy
+      // has the first element to mark.
+      window.scrollTo({ top: 0 });
+      await waitUntil(
+        () => inViewHref(el) === `#${firstId}`,
+        'the scroll spy never marked the first element',
       );
 
       // Move the highlight off the first element, so a spy that comes back


### PR DESCRIPTION
The otp-input story takes focus as it loads, which scrolls the page. The test asserted on the scroll spy before waiting for the stories to settle, so the first anchor was already out of view.

Green on main either way. It only fails once the demo has enough elements to scroll, which is the radio player stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017RuJpnAKn9TtFvMxcEgwdm